### PR TITLE
Fix Gateway page wrapper registration

### DIFF
--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -220,7 +220,6 @@ export default class GatewayApiRenderer extends Renderer.LensExtension {
     {
       id: "gateway-api",
       title: "Gateway API",
-      target: { pageId: "gateway" },
       components: {
         Icon: GatewayApiIcon,
       },
@@ -232,7 +231,13 @@ export default class GatewayApiRenderer extends Renderer.LensExtension {
       target: { pageId: "gatewayclass" },
       components: {},
     },
-    { id: "gateway", parentId: "gateway-api", title: "Gateways", target: { pageId: "gateway" }, components: {} },
+    {
+      id: "gateway",
+      parentId: "gateway-api",
+      title: "Gateways",
+      target: { pageId: "gateway" },
+      components: {},
+    },
     {
       id: "httproute",
       parentId: "gateway-api",


### PR DESCRIPTION
This fixes the Gateway page registration so it is wrapped consistently with the other Gateway API pages.

The top-level gateway-api menu entry no longer targets the same page as the gateway child entry, which lets Freelens resolve the sibling page wrapper correctly. I also aligned the clusterPageMenus gateway entry code format with the rest of the entries, as it was inconsistent.