### PR TITLE
Improve ReferenceGrant pages and extend API compatibility

### DIFF
--- a/src/renderer/details/gateway-api/index.ts
+++ b/src/renderer/details/gateway-api/index.ts
@@ -4,6 +4,7 @@ import { GatewayDetails as GatewayDetails_v1 } from "./gateway-details-v1";
 import { GRPCRouteDetails as GRPCRouteDetails_v1 } from "./grpc-route-details-v1";
 import { HTTPRouteDetails as HTTPRouteDetails_v1 } from "./http-route-details-v1";
 import { ReferenceGrantDetails as ReferenceGrantDetails_v1 } from "./reference-grant-details-v1";
+import { ReferenceGrantDetails as ReferenceGrantDetails_v1beta1 } from "./reference-grant-details-v1beta1";
 import { TCPRouteDetails as TCPRouteDetails_v1alpha2 } from "./tcp-route-details-v1alpha2";
 import { TLSRouteDetails as TLSRouteDetails_v1 } from "./tls-route-details-v1";
 import { UDPRouteDetails as UDPRouteDetails_v1alpha2 } from "./udp-route-details-v1alpha2";
@@ -15,6 +16,7 @@ export {
   GRPCRouteDetails_v1,
   HTTPRouteDetails_v1,
   ReferenceGrantDetails_v1,
+  ReferenceGrantDetails_v1beta1,
   TCPRouteDetails_v1alpha2,
   TLSRouteDetails_v1,
   UDPRouteDetails_v1alpha2,

--- a/src/renderer/details/gateway-api/reference-grant-details-v1beta1.tsx
+++ b/src/renderer/details/gateway-api/reference-grant-details-v1beta1.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { ReferenceGrant } from "../../k8s/gateway-api";
+import { ReferenceGrant } from "../../k8s/gateway-api/reference-grant-v1beta1";
 import { observer } from "../../observer";
 
 const {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -31,8 +31,8 @@ import { GatewayClassesPage as GatewayClassesPage_v1 } from "./pages/gateway-api
 import { GatewaysPage as GatewaysPage_v1 } from "./pages/gateway-api/gateways-page-v1";
 import { GRPCRoutesPage as GRPCRoutesPage_v1 } from "./pages/gateway-api/grpc-routes-page-v1";
 import { HTTPRoutesPage as HTTPRoutesPage_v1 } from "./pages/gateway-api/http-routes-page-v1";
-import { ReferenceGrantsPage as ReferenceGrantsPage_v1 } from "./pages/gateway-api/reference-grants-page-v1";
-import { ReferenceGrantsPage as ReferenceGrantsPage_v1beta1 } from "./pages/gateway-api/reference-grants-page-v1beta1";
+import { ReferenceGrantsPage as ReferenceGrantsPage_v1 } from "./pages/gateway-api/reference-grants/reference-grants-page-v1";
+import { ReferenceGrantsPage as ReferenceGrantsPage_v1beta1 } from "./pages/gateway-api/reference-grants/reference-grants-page-v1beta1";
 import { TCPRoutesPage as TCPRoutesPage_v1alpha2 } from "./pages/gateway-api/tcp-routes-page-v1alpha2";
 import { TLSRoutesPage as TLSRoutesPage_v1 } from "./pages/gateway-api/tls-routes-page-v1";
 import { UDPRoutesPage as UDPRoutesPage_v1alpha2 } from "./pages/gateway-api/udp-routes-page-v1alpha2";

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -11,6 +11,7 @@ import { GatewayDetails as GatewayDetails_v1 } from "./details/gateway-api/gatew
 import { GRPCRouteDetails as GRPCRouteDetails_v1 } from "./details/gateway-api/grpc-route-details-v1";
 import { HTTPRouteDetails as HTTPRouteDetails_v1 } from "./details/gateway-api/http-route-details-v1";
 import { ReferenceGrantDetails as ReferenceGrantDetails_v1 } from "./details/gateway-api/reference-grant-details-v1";
+import { ReferenceGrantDetails as ReferenceGrantDetails_v1beta1 } from "./details/gateway-api/reference-grant-details-v1beta1";
 import { TCPRouteDetails as TCPRouteDetails_v1alpha2 } from "./details/gateway-api/tcp-route-details-v1alpha2";
 import { TLSRouteDetails as TLSRouteDetails_v1 } from "./details/gateway-api/tls-route-details-v1";
 import { UDPRouteDetails as UDPRouteDetails_v1alpha2 } from "./details/gateway-api/udp-route-details-v1alpha2";
@@ -21,6 +22,7 @@ import { Gateway as Gateway_v1 } from "./k8s/gateway-api/gateway-v1";
 import { GRPCRoute as GRPCRoute_v1 } from "./k8s/gateway-api/grpc-route-v1";
 import { HTTPRoute as HTTPRoute_v1 } from "./k8s/gateway-api/http-route-v1";
 import { ReferenceGrant as ReferenceGrant_v1 } from "./k8s/gateway-api/reference-grant-v1";
+import { ReferenceGrant as ReferenceGrant_v1beta1 } from "./k8s/gateway-api/reference-grant-v1beta1";
 import { TCPRoute as TCPRoute_v1alpha2 } from "./k8s/gateway-api/tcp-route-v1alpha2";
 import { TLSRoute as TLSRoute_v1 } from "./k8s/gateway-api/tls-route-v1";
 import { UDPRoute as UDPRoute_v1alpha2 } from "./k8s/gateway-api/udp-route-v1alpha2";
@@ -30,6 +32,7 @@ import { GatewaysPage as GatewaysPage_v1 } from "./pages/gateway-api/gateways-pa
 import { GRPCRoutesPage as GRPCRoutesPage_v1 } from "./pages/gateway-api/grpc-routes-page-v1";
 import { HTTPRoutesPage as HTTPRoutesPage_v1 } from "./pages/gateway-api/http-routes-page-v1";
 import { ReferenceGrantsPage as ReferenceGrantsPage_v1 } from "./pages/gateway-api/reference-grants-page-v1";
+import { ReferenceGrantsPage as ReferenceGrantsPage_v1beta1 } from "./pages/gateway-api/reference-grants-page-v1beta1";
 import { TCPRoutesPage as TCPRoutesPage_v1alpha2 } from "./pages/gateway-api/tcp-routes-page-v1alpha2";
 import { TLSRoutesPage as TLSRoutesPage_v1 } from "./pages/gateway-api/tls-routes-page-v1";
 import { UDPRoutesPage as UDPRoutesPage_v1alpha2 } from "./pages/gateway-api/udp-routes-page-v1alpha2";
@@ -100,6 +103,16 @@ export default class GatewayApiRenderer extends Renderer.LensExtension {
       priority: 10,
       components: {
         Details: (props: Renderer.Component.KubeObjectDetailsProps<any>) => <ReferenceGrantDetails_v1 {...props} />,
+      },
+    },
+    {
+      kind: ReferenceGrant_v1beta1.kind,
+      apiVersions: ReferenceGrant_v1beta1.crd.apiVersions,
+      priority: 10,
+      components: {
+        Details: (props: Renderer.Component.KubeObjectDetailsProps<any>) => (
+          <ReferenceGrantDetails_v1beta1 {...props} />
+        ),
       },
     },
     {
@@ -177,6 +190,11 @@ export default class GatewayApiRenderer extends Renderer.LensExtension {
             kubeObjectClass: ReferenceGrant_v1,
             PageComponent: ReferenceGrantsPage_v1,
             version: "v1",
+          },
+          {
+            kubeObjectClass: ReferenceGrant_v1beta1,
+            PageComponent: ReferenceGrantsPage_v1beta1,
+            version: "v1beta1",
           },
         ]),
       },

--- a/src/renderer/k8s/gateway-api/index.ts
+++ b/src/renderer/k8s/gateway-api/index.ts
@@ -25,6 +25,11 @@ import {
   ReferenceGrantStore as ReferenceGrantStore_v1,
 } from "./reference-grant-v1";
 import {
+  ReferenceGrant as ReferenceGrant_v1beta1,
+  ReferenceGrantApi as ReferenceGrantApi_v1beta1,
+  ReferenceGrantStore as ReferenceGrantStore_v1beta1,
+} from "./reference-grant-v1beta1";
+import {
   TCPRoute as TCPRoute_v1alpha2,
   TCPRouteApi as TCPRouteApi_v1alpha2,
   TCPRouteStore as TCPRouteStore_v1alpha2,
@@ -74,10 +79,13 @@ export {
   HTTPRouteStore_v1 as HTTPRouteStore,
   ReferenceGrant_v1,
   ReferenceGrant_v1 as ReferenceGrant,
+  ReferenceGrant_v1beta1,
   ReferenceGrantApi_v1,
   ReferenceGrantApi_v1 as ReferenceGrantApi,
+  ReferenceGrantApi_v1beta1,
   ReferenceGrantStore_v1,
   ReferenceGrantStore_v1 as ReferenceGrantStore,
+  ReferenceGrantStore_v1beta1,
   TCPRoute_v1alpha2,
   TCPRoute_v1alpha2 as TCPRoute,
   TCPRouteApi_v1alpha2,

--- a/src/renderer/pages/gateway-api/index.ts
+++ b/src/renderer/pages/gateway-api/index.ts
@@ -3,8 +3,8 @@ import { GatewayClassesPage as GatewayClassesPage_v1 } from "./gateway-classes-p
 import { GatewaysPage as GatewaysPage_v1 } from "./gateways-page-v1";
 import { GRPCRoutesPage as GRPCRoutesPage_v1 } from "./grpc-routes-page-v1";
 import { HTTPRoutesPage as HTTPRoutesPage_v1 } from "./http-routes-page-v1";
-import { ReferenceGrantsPage as ReferenceGrantsPage_v1 } from "./reference-grants-page-v1";
-import { ReferenceGrantsPage as ReferenceGrantsPage_v1beta1 } from "./reference-grants-page-v1beta1";
+import { ReferenceGrantsPage as ReferenceGrantsPage_v1 } from "./reference-grants/reference-grants-page-v1";
+import { ReferenceGrantsPage as ReferenceGrantsPage_v1beta1 } from "./reference-grants/reference-grants-page-v1beta1";
 import { TCPRoutesPage as TCPRoutesPage_v1alpha2 } from "./tcp-routes-page-v1alpha2";
 import { TLSRoutesPage as TLSRoutesPage_v1 } from "./tls-routes-page-v1";
 import { UDPRoutesPage as UDPRoutesPage_v1alpha2 } from "./udp-routes-page-v1alpha2";

--- a/src/renderer/pages/gateway-api/index.ts
+++ b/src/renderer/pages/gateway-api/index.ts
@@ -4,6 +4,7 @@ import { GatewaysPage as GatewaysPage_v1 } from "./gateways-page-v1";
 import { GRPCRoutesPage as GRPCRoutesPage_v1 } from "./grpc-routes-page-v1";
 import { HTTPRoutesPage as HTTPRoutesPage_v1 } from "./http-routes-page-v1";
 import { ReferenceGrantsPage as ReferenceGrantsPage_v1 } from "./reference-grants-page-v1";
+import { ReferenceGrantsPage as ReferenceGrantsPage_v1beta1 } from "./reference-grants-page-v1beta1";
 import { TCPRoutesPage as TCPRoutesPage_v1alpha2 } from "./tcp-routes-page-v1alpha2";
 import { TLSRoutesPage as TLSRoutesPage_v1 } from "./tls-routes-page-v1";
 import { UDPRoutesPage as UDPRoutesPage_v1alpha2 } from "./udp-routes-page-v1alpha2";
@@ -15,6 +16,7 @@ export {
   GRPCRoutesPage_v1,
   HTTPRoutesPage_v1,
   ReferenceGrantsPage_v1,
+  ReferenceGrantsPage_v1beta1,
   TCPRoutesPage_v1alpha2,
   TLSRoutesPage_v1,
   UDPRoutesPage_v1alpha2,

--- a/src/renderer/pages/gateway-api/reference-grants-page-v1beta1.tsx
+++ b/src/renderer/pages/gateway-api/reference-grants-page-v1beta1.tsx
@@ -1,6 +1,6 @@
 import { Renderer } from "@freelensapp/extensions";
 import { withErrorPage } from "../../components/error-page";
-import { ReferenceGrant } from "../../k8s/gateway-api";
+import { ReferenceGrant } from "../../k8s/gateway-api/reference-grant-v1beta1";
 import { observer } from "../../observer";
 import { type GatewayPageProps, namespaceCell } from "./shared";
 

--- a/src/renderer/pages/gateway-api/reference-grants/reference-grant-summaries.test.ts
+++ b/src/renderer/pages/gateway-api/reference-grants/reference-grant-summaries.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+import { getReferenceGrantRowSummaries } from "./reference-grant-summaries";
+
+describe("ReferenceGrant summaries", () => {
+  test("formats a single from entry as namespace and kind", () => {
+    expect(
+      getReferenceGrantRowSummaries({
+        from: [{ group: "gateway.networking.k8s.io", kind: "HTTPRoute", namespace: "infra" }],
+      }).from,
+    ).toBe("infra/HTTPRoute");
+  });
+
+  test("formats multiple from entries as a comma-separated full summary", () => {
+    expect(
+      getReferenceGrantRowSummaries({
+        from: [
+          { group: "gateway.networking.k8s.io", kind: "HTTPRoute", namespace: "infra" },
+          { group: "gateway.networking.k8s.io", kind: "GRPCRoute", namespace: "shared" },
+        ],
+      }).from,
+    ).toBe("infra/HTTPRoute, shared/GRPCRoute");
+  });
+
+  test("formats an unnamed to target as kind only", () => {
+    expect(
+      getReferenceGrantRowSummaries({
+        to: [{ group: "", kind: "Service" }],
+      }).to,
+    ).toBe("Service");
+  });
+
+  test("formats a named to target as kind and name", () => {
+    expect(
+      getReferenceGrantRowSummaries({
+        to: [{ group: "", kind: "Secret", name: "tls-cert" }],
+      }).to,
+    ).toBe("Secret/tls-cert");
+  });
+
+  test("formats multiple to entries as a comma-separated full summary", () => {
+    expect(
+      getReferenceGrantRowSummaries({
+        to: [
+          { group: "", kind: "Service" },
+          { group: "", kind: "Secret", name: "tls-cert" },
+        ],
+      }).to,
+    ).toBe("Service, Secret/tls-cert");
+  });
+
+  test("formats an empty from list as a dash", () => {
+    expect(getReferenceGrantRowSummaries({ from: [] }).from).toBe("-");
+  });
+
+  test("formats an empty to list as a dash", () => {
+    expect(getReferenceGrantRowSummaries({ to: [] }).to).toBe("-");
+  });
+
+  test("returns short and full row summaries for both from and to", () => {
+    expect(
+      getReferenceGrantRowSummaries({
+        from: [
+          { group: "gateway.networking.k8s.io", kind: "HTTPRoute", namespace: "infra" },
+          { group: "gateway.networking.k8s.io", kind: "GRPCRoute", namespace: "shared" },
+        ],
+        to: [
+          { group: "", kind: "Service" },
+          { group: "", kind: "Secret", name: "tls-cert" },
+        ],
+      }),
+    ).toEqual({
+      from: "infra/HTTPRoute, shared/GRPCRoute",
+      to: "Service, Secret/tls-cert",
+    });
+  });
+});

--- a/src/renderer/pages/gateway-api/reference-grants/reference-grant-summaries.ts
+++ b/src/renderer/pages/gateway-api/reference-grants/reference-grant-summaries.ts
@@ -12,8 +12,8 @@ function formatReferenceGrantFromEntry(entry: { kind: string; namespace?: string
   return `${entry.namespace ?? ""}/${entry.kind}`;
 }
 
-function formatReferenceGrantFromSummary(spec: ReferenceGrantSummarySpec): string {
-  const from = spec.from ?? [];
+function formatReferenceGrantFromSummary(spec: ReferenceGrantSummarySpec | undefined): string {
+  const from = spec?.from ?? [];
 
   if (from.length === 0) {
     return "-";
@@ -26,8 +26,8 @@ function formatReferenceGrantToEntry(entry: { kind: string; name?: string }): st
   return entry.name ? `${entry.kind}/${entry.name}` : entry.kind;
 }
 
-function formatReferenceGrantToSummary(spec: ReferenceGrantSummarySpec): string {
-  const to = spec.to ?? [];
+function formatReferenceGrantToSummary(spec: ReferenceGrantSummarySpec | undefined): string {
+  const to = spec?.to ?? [];
 
   if (to.length === 0) {
     return "-";
@@ -36,7 +36,7 @@ function formatReferenceGrantToSummary(spec: ReferenceGrantSummarySpec): string 
   return to.map(formatReferenceGrantToEntry).join(", ");
 }
 
-export function getReferenceGrantRowSummaries(spec: ReferenceGrantSummarySpec): ReferenceGrantRowSummaries {
+export function getReferenceGrantRowSummaries(spec: ReferenceGrantSummarySpec | undefined): ReferenceGrantRowSummaries {
   return {
     from: formatReferenceGrantFromSummary(spec),
     to: formatReferenceGrantToSummary(spec),

--- a/src/renderer/pages/gateway-api/reference-grants/reference-grant-summaries.ts
+++ b/src/renderer/pages/gateway-api/reference-grants/reference-grant-summaries.ts
@@ -1,0 +1,44 @@
+export interface ReferenceGrantSummarySpec {
+  from?: Array<{ group?: string; kind: string; namespace?: string }>;
+  to?: Array<{ group?: string; kind: string; name?: string }>;
+}
+
+export interface ReferenceGrantRowSummaries {
+  from: string;
+  to: string;
+}
+
+function formatReferenceGrantFromEntry(entry: { kind: string; namespace?: string }): string {
+  return `${entry.namespace ?? ""}/${entry.kind}`;
+}
+
+function formatReferenceGrantFromSummary(spec: ReferenceGrantSummarySpec): string {
+  const from = spec.from ?? [];
+
+  if (from.length === 0) {
+    return "-";
+  }
+
+  return from.map(formatReferenceGrantFromEntry).join(", ");
+}
+
+function formatReferenceGrantToEntry(entry: { kind: string; name?: string }): string {
+  return entry.name ? `${entry.kind}/${entry.name}` : entry.kind;
+}
+
+function formatReferenceGrantToSummary(spec: ReferenceGrantSummarySpec): string {
+  const to = spec.to ?? [];
+
+  if (to.length === 0) {
+    return "-";
+  }
+
+  return to.map(formatReferenceGrantToEntry).join(", ");
+}
+
+export function getReferenceGrantRowSummaries(spec: ReferenceGrantSummarySpec): ReferenceGrantRowSummaries {
+  return {
+    from: formatReferenceGrantFromSummary(spec),
+    to: formatReferenceGrantToSummary(spec),
+  };
+}

--- a/src/renderer/pages/gateway-api/reference-grants/reference-grants-page-v1.tsx
+++ b/src/renderer/pages/gateway-api/reference-grants/reference-grants-page-v1.tsx
@@ -4,6 +4,8 @@ import { ReferenceGrant } from "../../../k8s/gateway-api";
 import { observer } from "../../../observer";
 import { type GatewayPageProps, namespaceCell } from "../shared";
 import { getReferenceGrantRowSummaries } from "./reference-grant-summaries";
+import styles from "./reference-grants-page.module.scss";
+import stylesInline from "./reference-grants-page.module.scss?inline";
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, WithTooltip },
@@ -26,38 +28,41 @@ export const ReferenceGrantsPage = observer((props: GatewayPageProps) =>
     const store = ReferenceGrant.getStore<ReferenceGrant>();
 
     return (
-      <KubeObjectListLayout<ReferenceGrant, any>
-        tableId={`${ReferenceGrant.crd.plural}Table`}
-        className="ReferenceGrantsPage"
-        store={store}
-        sortingCallbacks={{
-          name: (item: ReferenceGrant) => item.getName(),
-          namespace: (item: ReferenceGrant) => item.getNs() ?? "",
-          from: (item: ReferenceGrant) => getFromCount(item),
-          to: (item: ReferenceGrant) => getToCount(item),
-          age: (item: ReferenceGrant) => item.getCreationTimestamp(),
-        }}
-        searchFilters={[(item: ReferenceGrant) => item.getSearchFields()]}
-        renderHeaderTitle={ReferenceGrant.crd.title}
-        renderTableHeader={[
-          { title: "Name", sortBy: "name" },
-          { title: "Namespace", sortBy: "namespace" },
-          { title: "From", sortBy: "from" },
-          { title: "To", sortBy: "to" },
-          { title: "Age", sortBy: "age" },
-        ]}
-        renderTableContents={(item: ReferenceGrant) => {
-          const summaries = getReferenceGrantRowSummaries(item.spec ?? {});
+      <>
+        <style>{stylesInline}</style>
+        <KubeObjectListLayout<ReferenceGrant, any>
+          tableId={`${ReferenceGrant.crd.plural}Table`}
+          className={styles.page}
+          store={store}
+          sortingCallbacks={{
+            name: (item: ReferenceGrant) => item.getName(),
+            namespace: (item: ReferenceGrant) => item.getNs() ?? "",
+            from: (item: ReferenceGrant) => getFromCount(item),
+            to: (item: ReferenceGrant) => getToCount(item),
+            age: (item: ReferenceGrant) => item.getCreationTimestamp(),
+          }}
+          searchFilters={[(item: ReferenceGrant) => item.getSearchFields()]}
+          renderHeaderTitle={ReferenceGrant.crd.title}
+          renderTableHeader={[
+            { title: "Name", sortBy: "name", className: styles.name },
+            { title: "Namespace", sortBy: "namespace", className: styles.namespace },
+            { title: "From", sortBy: "from", className: styles.from },
+            { title: "To", sortBy: "to", className: styles.to },
+            { title: "Age", sortBy: "age", className: styles.age },
+          ]}
+          renderTableContents={(item: ReferenceGrant) => {
+            const summaries = getReferenceGrantRowSummaries(item.spec ?? {});
 
-          return [
-            <WithTooltip>{item.getName()}</WithTooltip>,
-            namespaceCell(item.getNs()),
-            <WithTooltip>{summaries.from}</WithTooltip>,
-            <WithTooltip>{summaries.to}</WithTooltip>,
-            <KubeObjectAge object={item} key="age" />,
-          ];
-        }}
-      />
+            return [
+              <WithTooltip>{item.getName()}</WithTooltip>,
+              namespaceCell(item.getNs()),
+              <WithTooltip>{summaries.from}</WithTooltip>,
+              <WithTooltip>{summaries.to}</WithTooltip>,
+              <KubeObjectAge object={item} key="age" />,
+            ];
+          }}
+        />
+      </>
     );
   }),
 );

--- a/src/renderer/pages/gateway-api/reference-grants/reference-grants-page-v1.tsx
+++ b/src/renderer/pages/gateway-api/reference-grants/reference-grants-page-v1.tsx
@@ -1,8 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
-import { withErrorPage } from "../../components/error-page";
-import { ReferenceGrant } from "../../k8s/gateway-api/reference-grant-v1beta1";
-import { observer } from "../../observer";
-import { type GatewayPageProps, namespaceCell } from "./shared";
+import { withErrorPage } from "../../../components/error-page";
+import { ReferenceGrant } from "../../../k8s/gateway-api";
+import { observer } from "../../../observer";
+import { type GatewayPageProps, namespaceCell } from "../shared";
+import { getReferenceGrantRowSummaries } from "./reference-grant-summaries";
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, WithTooltip },
@@ -45,13 +46,17 @@ export const ReferenceGrantsPage = observer((props: GatewayPageProps) =>
           { title: "To", sortBy: "to" },
           { title: "Age", sortBy: "age" },
         ]}
-        renderTableContents={(item: ReferenceGrant) => [
-          <WithTooltip>{item.getName()}</WithTooltip>,
-          namespaceCell(item.getNs()),
-          <WithTooltip>{String(getFromCount(item))}</WithTooltip>,
-          <WithTooltip>{String(getToCount(item))}</WithTooltip>,
-          <KubeObjectAge object={item} key="age" />,
-        ]}
+        renderTableContents={(item: ReferenceGrant) => {
+          const summaries = getReferenceGrantRowSummaries(item.spec ?? {});
+
+          return [
+            <WithTooltip>{item.getName()}</WithTooltip>,
+            namespaceCell(item.getNs()),
+            <WithTooltip>{summaries.from}</WithTooltip>,
+            <WithTooltip>{summaries.to}</WithTooltip>,
+            <KubeObjectAge object={item} key="age" />,
+          ];
+        }}
       />
     );
   }),

--- a/src/renderer/pages/gateway-api/reference-grants/reference-grants-page-v1.tsx
+++ b/src/renderer/pages/gateway-api/reference-grants/reference-grants-page-v1.tsx
@@ -11,18 +11,6 @@ const {
   Component: { KubeObjectAge, KubeObjectListLayout, WithTooltip },
 } = Renderer;
 
-function getFromCount(item: ReferenceGrant): number {
-  return typeof (item as any).getFromCount === "function"
-    ? (item as any).getFromCount()
-    : ((item as any).spec?.from ?? []).length;
-}
-
-function getToCount(item: ReferenceGrant): number {
-  return typeof (item as any).getToCount === "function"
-    ? (item as any).getToCount()
-    : ((item as any).spec?.to ?? []).length;
-}
-
 export const ReferenceGrantsPage = observer((props: GatewayPageProps) =>
   withErrorPage(props, () => {
     const store = ReferenceGrant.getStore<ReferenceGrant>();
@@ -37,8 +25,8 @@ export const ReferenceGrantsPage = observer((props: GatewayPageProps) =>
           sortingCallbacks={{
             name: (item: ReferenceGrant) => item.getName(),
             namespace: (item: ReferenceGrant) => item.getNs() ?? "",
-            from: (item: ReferenceGrant) => getFromCount(item),
-            to: (item: ReferenceGrant) => getToCount(item),
+            from: (item: ReferenceGrant) => getReferenceGrantRowSummaries(item.spec).from,
+            to: (item: ReferenceGrant) => getReferenceGrantRowSummaries(item.spec).to,
             age: (item: ReferenceGrant) => item.getCreationTimestamp(),
           }}
           searchFilters={[(item: ReferenceGrant) => item.getSearchFields()]}
@@ -51,7 +39,7 @@ export const ReferenceGrantsPage = observer((props: GatewayPageProps) =>
             { title: "Age", sortBy: "age", className: styles.age },
           ]}
           renderTableContents={(item: ReferenceGrant) => {
-            const summaries = getReferenceGrantRowSummaries(item.spec ?? {});
+            const summaries = getReferenceGrantRowSummaries(item.spec);
 
             return [
               <WithTooltip>{item.getName()}</WithTooltip>,

--- a/src/renderer/pages/gateway-api/reference-grants/reference-grants-page-v1beta1.tsx
+++ b/src/renderer/pages/gateway-api/reference-grants/reference-grants-page-v1beta1.tsx
@@ -4,6 +4,8 @@ import { ReferenceGrant } from "../../../k8s/gateway-api/reference-grant-v1beta1
 import { observer } from "../../../observer";
 import { type GatewayPageProps, namespaceCell } from "../shared";
 import { getReferenceGrantRowSummaries } from "./reference-grant-summaries";
+import styles from "./reference-grants-page.module.scss";
+import stylesInline from "./reference-grants-page.module.scss?inline";
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, WithTooltip },
@@ -26,38 +28,41 @@ export const ReferenceGrantsPage = observer((props: GatewayPageProps) =>
     const store = ReferenceGrant.getStore<ReferenceGrant>();
 
     return (
-      <KubeObjectListLayout<ReferenceGrant, any>
-        tableId={`${ReferenceGrant.crd.plural}Table`}
-        className="ReferenceGrantsPage"
-        store={store}
-        sortingCallbacks={{
-          name: (item: ReferenceGrant) => item.getName(),
-          namespace: (item: ReferenceGrant) => item.getNs() ?? "",
-          from: (item: ReferenceGrant) => getFromCount(item),
-          to: (item: ReferenceGrant) => getToCount(item),
-          age: (item: ReferenceGrant) => item.getCreationTimestamp(),
-        }}
-        searchFilters={[(item: ReferenceGrant) => item.getSearchFields()]}
-        renderHeaderTitle={ReferenceGrant.crd.title}
-        renderTableHeader={[
-          { title: "Name", sortBy: "name" },
-          { title: "Namespace", sortBy: "namespace" },
-          { title: "From", sortBy: "from" },
-          { title: "To", sortBy: "to" },
-          { title: "Age", sortBy: "age" },
-        ]}
-        renderTableContents={(item: ReferenceGrant) => {
-          const summaries = getReferenceGrantRowSummaries(item.spec ?? {});
+      <>
+        <style>{stylesInline}</style>
+        <KubeObjectListLayout<ReferenceGrant, any>
+          tableId={`${ReferenceGrant.crd.plural}Table`}
+          className={styles.page}
+          store={store}
+          sortingCallbacks={{
+            name: (item: ReferenceGrant) => item.getName(),
+            namespace: (item: ReferenceGrant) => item.getNs() ?? "",
+            from: (item: ReferenceGrant) => getFromCount(item),
+            to: (item: ReferenceGrant) => getToCount(item),
+            age: (item: ReferenceGrant) => item.getCreationTimestamp(),
+          }}
+          searchFilters={[(item: ReferenceGrant) => item.getSearchFields()]}
+          renderHeaderTitle={ReferenceGrant.crd.title}
+          renderTableHeader={[
+            { title: "Name", sortBy: "name", className: styles.name },
+            { title: "Namespace", sortBy: "namespace", className: styles.namespace },
+            { title: "From", sortBy: "from", className: styles.from },
+            { title: "To", sortBy: "to", className: styles.to },
+            { title: "Age", sortBy: "age", className: styles.age },
+          ]}
+          renderTableContents={(item: ReferenceGrant) => {
+            const summaries = getReferenceGrantRowSummaries(item.spec ?? {});
 
-          return [
-            <WithTooltip>{item.getName()}</WithTooltip>,
-            namespaceCell(item.getNs()),
-            <WithTooltip>{summaries.from}</WithTooltip>,
-            <WithTooltip>{summaries.to}</WithTooltip>,
-            <KubeObjectAge object={item} key="age" />,
-          ];
-        }}
-      />
+            return [
+              <WithTooltip>{item.getName()}</WithTooltip>,
+              namespaceCell(item.getNs()),
+              <WithTooltip>{summaries.from}</WithTooltip>,
+              <WithTooltip>{summaries.to}</WithTooltip>,
+              <KubeObjectAge object={item} key="age" />,
+            ];
+          }}
+        />
+      </>
     );
   }),
 );

--- a/src/renderer/pages/gateway-api/reference-grants/reference-grants-page-v1beta1.tsx
+++ b/src/renderer/pages/gateway-api/reference-grants/reference-grants-page-v1beta1.tsx
@@ -11,18 +11,6 @@ const {
   Component: { KubeObjectAge, KubeObjectListLayout, WithTooltip },
 } = Renderer;
 
-function getFromCount(item: ReferenceGrant): number {
-  return typeof (item as any).getFromCount === "function"
-    ? (item as any).getFromCount()
-    : ((item as any).spec?.from ?? []).length;
-}
-
-function getToCount(item: ReferenceGrant): number {
-  return typeof (item as any).getToCount === "function"
-    ? (item as any).getToCount()
-    : ((item as any).spec?.to ?? []).length;
-}
-
 export const ReferenceGrantsPage = observer((props: GatewayPageProps) =>
   withErrorPage(props, () => {
     const store = ReferenceGrant.getStore<ReferenceGrant>();
@@ -37,8 +25,8 @@ export const ReferenceGrantsPage = observer((props: GatewayPageProps) =>
           sortingCallbacks={{
             name: (item: ReferenceGrant) => item.getName(),
             namespace: (item: ReferenceGrant) => item.getNs() ?? "",
-            from: (item: ReferenceGrant) => getFromCount(item),
-            to: (item: ReferenceGrant) => getToCount(item),
+            from: (item: ReferenceGrant) => getReferenceGrantRowSummaries(item.spec).from,
+            to: (item: ReferenceGrant) => getReferenceGrantRowSummaries(item.spec).to,
             age: (item: ReferenceGrant) => item.getCreationTimestamp(),
           }}
           searchFilters={[(item: ReferenceGrant) => item.getSearchFields()]}
@@ -51,7 +39,7 @@ export const ReferenceGrantsPage = observer((props: GatewayPageProps) =>
             { title: "Age", sortBy: "age", className: styles.age },
           ]}
           renderTableContents={(item: ReferenceGrant) => {
-            const summaries = getReferenceGrantRowSummaries(item.spec ?? {});
+            const summaries = getReferenceGrantRowSummaries(item.spec);
 
             return [
               <WithTooltip>{item.getName()}</WithTooltip>,

--- a/src/renderer/pages/gateway-api/reference-grants/reference-grants-page-v1beta1.tsx
+++ b/src/renderer/pages/gateway-api/reference-grants/reference-grants-page-v1beta1.tsx
@@ -1,8 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
-import { withErrorPage } from "../../components/error-page";
-import { ReferenceGrant } from "../../k8s/gateway-api";
-import { observer } from "../../observer";
-import { type GatewayPageProps, namespaceCell } from "./shared";
+import { withErrorPage } from "../../../components/error-page";
+import { ReferenceGrant } from "../../../k8s/gateway-api/reference-grant-v1beta1";
+import { observer } from "../../../observer";
+import { type GatewayPageProps, namespaceCell } from "../shared";
+import { getReferenceGrantRowSummaries } from "./reference-grant-summaries";
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, WithTooltip },
@@ -45,13 +46,17 @@ export const ReferenceGrantsPage = observer((props: GatewayPageProps) =>
           { title: "To", sortBy: "to" },
           { title: "Age", sortBy: "age" },
         ]}
-        renderTableContents={(item: ReferenceGrant) => [
-          <WithTooltip>{item.getName()}</WithTooltip>,
-          namespaceCell(item.getNs()),
-          <WithTooltip>{String(getFromCount(item))}</WithTooltip>,
-          <WithTooltip>{String(getToCount(item))}</WithTooltip>,
-          <KubeObjectAge object={item} key="age" />,
-        ]}
+        renderTableContents={(item: ReferenceGrant) => {
+          const summaries = getReferenceGrantRowSummaries(item.spec ?? {});
+
+          return [
+            <WithTooltip>{item.getName()}</WithTooltip>,
+            namespaceCell(item.getNs()),
+            <WithTooltip>{summaries.from}</WithTooltip>,
+            <WithTooltip>{summaries.to}</WithTooltip>,
+            <KubeObjectAge object={item} key="age" />,
+          ];
+        }}
       />
     );
   }),

--- a/src/renderer/pages/gateway-api/reference-grants/reference-grants-page.module.d.scss.ts
+++ b/src/renderer/pages/gateway-api/reference-grants/reference-grants-page.module.d.scss.ts
@@ -1,0 +1,10 @@
+declare const classNames: {
+  readonly page: "page";
+  readonly tableCell: "tableCell";
+  readonly name: "name";
+  readonly namespace: "namespace";
+  readonly from: "from";
+  readonly to: "to";
+  readonly age: "age";
+};
+export = classNames;

--- a/src/renderer/pages/gateway-api/reference-grants/reference-grants-page.module.scss
+++ b/src/renderer/pages/gateway-api/reference-grants/reference-grants-page.module.scss
@@ -1,0 +1,23 @@
+.page {
+  :global(.TableCell) {
+    &.name {
+      flex-grow: 2;
+    }
+
+    &.namespace {
+      flex-grow: 1;
+    }
+
+    &.from {
+      flex-grow: 2;
+    }
+
+    &.to {
+      flex-grow: 2;
+    }
+
+    &.age {
+      flex-grow: 0.5;
+    }
+  }
+}


### PR DESCRIPTION
Add ReferenceGrant `v1beta1` support alongside `v1` for better Gateway API v1.5+ compatibility.

This also replaces the `From` and `To` count cells with actual summaries, keeping the details views unchanged, and adjusts the list column widths so the summary columns have more room.

The summary rendering follows the simpler Secrets/ConfigMaps pattern for now. Another approach, for example using linked resources, could be added later.