### PR TITLE
Add Gateway API overview page

### DIFF
--- a/src/renderer/api/k8s/index.ts
+++ b/src/renderer/api/k8s/index.ts
@@ -50,6 +50,7 @@ import {
   UDPRouteStore as UDPRouteStore_v1alpha2,
 } from "./udp-route-v1alpha2";
 
+export * from "./statuses";
 export * from "./types";
 export {
   BackendTLSPolicy_v1,

--- a/src/renderer/api/k8s/statuses.test.ts
+++ b/src/renderer/api/k8s/statuses.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "vitest";
+import { getStatusCategory } from "./statuses";
+
+describe("getStatusCategory", () => {
+  test("returns Unknown when there is no status", () => {
+    expect(getStatusCategory({})).toBe("Unknown");
+    expect(getStatusCategory({ status: undefined })).toBe("Unknown");
+    expect(getStatusCategory({ status: {} })).toBe("Unknown");
+  });
+
+  test("treats a Gateway with all top-level conditions True as Ready", () => {
+    expect(
+      getStatusCategory({
+        status: {
+          conditions: [
+            { type: "Accepted", status: "True", reason: "Accepted" },
+            { type: "Programmed", status: "True", reason: "Programmed" },
+          ],
+        },
+      }),
+    ).toBe("Ready");
+  });
+
+  test("treats a False condition as NotReady", () => {
+    expect(
+      getStatusCategory({
+        status: {
+          conditions: [
+            { type: "Accepted", status: "True", reason: "Accepted" },
+            { type: "Programmed", status: "False", reason: "Invalid" },
+          ],
+        },
+      }),
+    ).toBe("NotReady");
+  });
+
+  test("treats an Unknown condition status as InProgress", () => {
+    expect(
+      getStatusCategory({
+        status: {
+          conditions: [{ type: "Accepted", status: "Unknown", reason: "Pending" }],
+        },
+      }),
+    ).toBe("InProgress");
+  });
+
+  test("treats transient reasons as InProgress even when the status is False", () => {
+    expect(
+      getStatusCategory({
+        status: {
+          conditions: [{ type: "Programmed", status: "False", reason: "Pending" }],
+        },
+      }),
+    ).toBe("InProgress");
+  });
+
+  test("aggregates route conditions from parents", () => {
+    expect(
+      getStatusCategory({
+        status: {
+          parents: [
+            {
+              conditions: [
+                { type: "Accepted", status: "True", reason: "Accepted" },
+                { type: "ResolvedRefs", status: "True", reason: "ResolvedRefs" },
+              ],
+            },
+          ],
+        },
+      }),
+    ).toBe("Ready");
+  });
+
+  test("reports a route as NotReady when any parent has a failing condition", () => {
+    expect(
+      getStatusCategory({
+        status: {
+          parents: [
+            { conditions: [{ type: "Accepted", status: "True", reason: "Accepted" }] },
+            { conditions: [{ type: "ResolvedRefs", status: "False", reason: "BackendNotFound" }] },
+          ],
+        },
+      }),
+    ).toBe("NotReady");
+  });
+
+  test("aggregates policy conditions from nested ancestor entries", () => {
+    expect(
+      getStatusCategory({
+        status: {
+          conditions: [
+            {
+              ancestorRef: { name: "gateway" },
+              controllerName: "example.com/controller",
+              conditions: [{ type: "Accepted", status: "True", reason: "Accepted" }],
+            },
+          ],
+        },
+      }),
+    ).toBe("Ready");
+  });
+
+  test("reports a policy as NotReady when a nested ancestor condition is False", () => {
+    expect(
+      getStatusCategory({
+        status: {
+          conditions: [
+            {
+              ancestorRef: { name: "gateway" },
+              controllerName: "example.com/controller",
+              conditions: [{ type: "Accepted", status: "False", reason: "Invalid" }],
+            },
+          ],
+        },
+      }),
+    ).toBe("NotReady");
+  });
+});

--- a/src/renderer/api/k8s/statuses.ts
+++ b/src/renderer/api/k8s/statuses.ts
@@ -1,0 +1,140 @@
+/**
+ * Status categorization for Gateway API resources.
+ *
+ * Gateway API resources report their state through `Condition`s, but the
+ * location of those conditions depends on the resource:
+ *
+ * - Top-level `status.conditions[]`: Gateway, GatewayClass, ListenerSet, Mesh
+ * - `status.parents[].conditions[]`: HTTPRoute, GRPCRoute, TCPRoute, TLSRoute, UDPRoute
+ * - `status.ancestors[].conditions[]` (modelled here as `status.conditions[].conditions[]`):
+ *   BackendTLSPolicy, BackendTrafficPolicy and other policy resources
+ *
+ * ReferenceGrant has no status and is therefore not categorizable.
+ *
+ * Condition reasons are defined by the upstream Gateway API Go types
+ * (sigs.k8s.io/gateway-api/apis/v1: gateway_types.go, gatewayclass_types.go,
+ * shared_types.go, and the policy condition reasons). The reasons that
+ * indicate transient/in-progress states (rather than a terminal failure) are
+ * collected in `inProgressReasons` below:
+ *
+ * - GatewayClass `Accepted`: Accepted, InvalidParameters, Unsupported, Pending, Waiting
+ * - Gateway `Accepted`: Accepted, Invalid, NoResources, Pending, UnsupportedAddress,
+ *   ListenersNotValid
+ * - Gateway `Programmed`: Programmed, Invalid, NoResources, Pending, AddressNotAssigned,
+ *   AddressNotUsable
+ * - Route `Accepted`: Accepted, NotAllowedByListeners, NoMatchingListenerHostname,
+ *   NoMatchingParent, UnsupportedValue, Pending, GatewayNotProgrammed
+ * - Route `ResolvedRefs`: ResolvedRefs, RefNotPermitted, InvalidKind, BackendNotFound,
+ *   UnsupportedProtocol
+ * - Policy `Accepted`: Accepted, Invalid, Pending
+ */
+
+export type GatewayApiStatusCategory = "Ready" | "NotReady" | "InProgress" | "Unknown";
+
+/**
+ * Condition reasons that represent a transient / in-progress state rather than a
+ * terminal failure. When such a reason is present the resource is reported as
+ * "In Progress" even if the corresponding condition status is `False`.
+ */
+const inProgressReasons = new Set<string>([
+  "Pending",
+  "Waiting",
+  "Reconciling",
+  "NotReconciled",
+  "GatewayNotProgrammed",
+]);
+
+interface NormalizedCondition {
+  status: string;
+  reason: string;
+}
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function pushCondition(target: NormalizedCondition[], value: unknown): void {
+  const condition = toRecord(value);
+  if (!condition || typeof condition.status !== "string") {
+    return;
+  }
+  target.push({
+    status: condition.status,
+    reason: typeof condition.reason === "string" ? condition.reason : "",
+  });
+}
+
+/**
+ * Collects all conditions from a Gateway API resource status, regardless of
+ * whether they live at the top level, under `parents[]`, or under nested
+ * ancestor entries.
+ */
+function collectConditions(status: unknown): NormalizedCondition[] {
+  const record = toRecord(status);
+  if (!record) {
+    return [];
+  }
+
+  const conditions: NormalizedCondition[] = [];
+
+  // Top-level conditions (Gateway, GatewayClass, ListenerSet, Mesh) and
+  // nested ancestor conditions (policies expose `status.ancestors[].conditions[]`
+  // which is modelled here as `status.conditions[].conditions[]`).
+  if (Array.isArray(record.conditions)) {
+    for (const entry of record.conditions) {
+      const entryRecord = toRecord(entry);
+      if (entryRecord && Array.isArray(entryRecord.conditions)) {
+        for (const nested of entryRecord.conditions) {
+          pushCondition(conditions, nested);
+        }
+      } else {
+        pushCondition(conditions, entry);
+      }
+    }
+  }
+
+  // Route conditions live under each parent reference.
+  if (Array.isArray(record.parents)) {
+    for (const parent of record.parents) {
+      const parentRecord = toRecord(parent);
+      if (parentRecord && Array.isArray(parentRecord.conditions)) {
+        for (const nested of parentRecord.conditions) {
+          pushCondition(conditions, nested);
+        }
+      }
+    }
+  }
+
+  return conditions;
+}
+
+function isInProgress(condition: NormalizedCondition): boolean {
+  return condition.status === "Unknown" || inProgressReasons.has(condition.reason);
+}
+
+/**
+ * Computes a coarse status category for any Gateway API resource based on its
+ * conditions. Resources without conditions (not yet reconciled, or without a
+ * status subresource such as ReferenceGrant) are reported as "Unknown".
+ */
+export function getStatusCategory(object: { status?: unknown }): GatewayApiStatusCategory {
+  const conditions = collectConditions(object.status);
+
+  if (conditions.length === 0) {
+    return "Unknown";
+  }
+
+  if (conditions.some((condition) => condition.status === "False" && !inProgressReasons.has(condition.reason))) {
+    return "NotReady";
+  }
+
+  if (conditions.some(isInProgress)) {
+    return "InProgress";
+  }
+
+  if (conditions.every((condition) => condition.status === "True")) {
+    return "Ready";
+  }
+
+  return "Unknown";
+}

--- a/src/renderer/components/gateway-api-events.tsx
+++ b/src/renderer/components/gateway-api-events.tsx
@@ -1,0 +1,190 @@
+import { Common, Renderer } from "@freelensapp/extensions";
+import { useState } from "react";
+import { observer } from "../observer";
+
+const {
+  Component: {
+    KubeObjectListLayout,
+    Icon,
+    KubeObjectAge,
+    NamespaceSelectBadge,
+    WithTooltip,
+    TabLayout,
+    ReactiveDuration,
+  },
+  Navigation: { getDetailsUrl, navigate },
+  K8sApi: { eventStore, apiManager },
+} = Renderer;
+
+const {
+  Util: { cssNames, stopPropagation },
+} = Common;
+
+const columnId = {
+  message: "message",
+  namespace: "namespace",
+  object: "object",
+  type: "type",
+  count: "count",
+  source: "source",
+  age: "age",
+  lastSeen: "last-seen",
+} as const;
+
+interface Sorting {
+  sortBy: string;
+  orderBy: "asc" | "desc";
+}
+
+/**
+ * Events belonging to Gateway API resources are recognized by the API group of
+ * their involved object (gateway.networking.k8s.io and the experimental
+ * gateway.networking.x-k8s.io group).
+ */
+function isGatewayApiEvent(event: Renderer.K8sApi.KubeEvent): boolean {
+  return event?.involvedObject?.apiVersion?.includes("gateway.networking.") ?? false;
+}
+
+const sortingCallbacks: Record<string, (event: Renderer.K8sApi.KubeEvent) => string | number> = {
+  [columnId.namespace]: (event) => event.getNs() ?? "",
+  [columnId.type]: (event) => event.type ?? "",
+  [columnId.object]: (event) => event.involvedObject.name,
+  [columnId.count]: (event) => event.count ?? 0,
+  [columnId.age]: (event) => -event.getCreationTimestamp(),
+  [columnId.lastSeen]: (event) => (event.lastTimestamp ? -new Date(event.lastTimestamp).getTime() : 0),
+};
+
+export interface GatewayApiEventsProps {
+  className?: string;
+  compact?: boolean;
+  compactLimit?: number;
+}
+
+export const GatewayApiEvents = observer((props: GatewayApiEventsProps) => {
+  const { compact, compactLimit, className, ...layoutProps } = props;
+
+  const [sorting, setSorting] = useState<Sorting>({ sortBy: columnId.age, orderBy: "asc" });
+
+  const items = (() => {
+    const filtered = eventStore.contextItems.filter(isGatewayApiEvent);
+    const callback = sortingCallbacks[sorting.sortBy];
+
+    if (!callback) {
+      return filtered;
+    }
+
+    return [...filtered].sort((a, b) => {
+      const valA = callback(a);
+      const valB = callback(b);
+      if (valA === valB) return 0;
+      const compare = valA > valB ? 1 : -1;
+      return sorting.orderBy === "asc" ? compare : -compare;
+    });
+  })();
+
+  const visibleItems = compact ? items.slice(0, compactLimit) : items;
+
+  const customizeHeader = ({ info, title, ...headerPlaceholders }: any) => {
+    const allEventsAreShown = visibleItems.length === items.length;
+
+    if (compact) {
+      if (allEventsAreShown) {
+        return { title };
+      }
+
+      return {
+        title,
+        info: (
+          <span>
+            {"("}
+            {visibleItems.length}
+            {" of "}
+            {items.length}
+            {")"}
+          </span>
+        ),
+      };
+    }
+
+    return {
+      info: (
+        <>
+          {info}
+          <Icon small material="help_outline" className="help-icon" tooltip={`Limited to ${eventStore.limit}`} />
+        </>
+      ),
+      title,
+      ...headerPlaceholders,
+    };
+  };
+
+  const events = (
+    <KubeObjectListLayout
+      {...layoutProps}
+      isConfigurable
+      tableId="gateway-api-events"
+      store={eventStore}
+      className={cssNames("Events", className, { compact })}
+      renderHeaderTitle="Gateway API Events"
+      customizeHeader={customizeHeader}
+      isSelectable={false}
+      getItems={() => visibleItems}
+      virtual={!compact}
+      tableProps={{
+        sortSyncWithUrl: false,
+        sortByDefault: sorting,
+        onSort: (params: Sorting) => setSorting(params),
+      }}
+      sortingCallbacks={sortingCallbacks}
+      searchFilters={[
+        (event: Renderer.K8sApi.KubeEvent) => event.getSearchFields(),
+        (event: Renderer.K8sApi.KubeEvent) => event.message ?? "",
+        (event: Renderer.K8sApi.KubeEvent) => event.getSource(),
+        (event: Renderer.K8sApi.KubeEvent) => event.involvedObject.name,
+      ]}
+      renderTableHeader={[
+        { title: "Type", className: "type", sortBy: columnId.type, id: columnId.type },
+        { title: "Message", className: "message", id: columnId.message },
+        { title: "Namespace", className: "namespace", sortBy: columnId.namespace, id: columnId.namespace },
+        { title: "Involved Object", className: "object", sortBy: columnId.object, id: columnId.object },
+        { title: "Source", className: "source", id: columnId.source },
+        { title: "Count", className: "count", sortBy: columnId.count, id: columnId.count },
+        { title: "Age", className: "age", sortBy: columnId.age, id: columnId.age },
+        { title: "Last Seen", className: "last-seen", sortBy: columnId.lastSeen, id: columnId.lastSeen },
+      ]}
+      renderTableContents={(event: Renderer.K8sApi.KubeEvent) => {
+        const { involvedObject, type, message } = event;
+        const isWarning = event.isWarning();
+        const detailsUrl = getDetailsUrl(apiManager.lookupApiLink(involvedObject, event));
+
+        return [
+          <WithTooltip>{type}</WithTooltip>,
+          {
+            className: cssNames({ warning: isWarning }),
+            title: <WithTooltip>{message}</WithTooltip>,
+          },
+          <NamespaceSelectBadge key="namespace" namespace={event.getNs()} />,
+          <a
+            key="link"
+            onClick={(e) => {
+              stopPropagation(e);
+              navigate(detailsUrl);
+            }}
+          >
+            <WithTooltip>{`${involvedObject.kind}: ${involvedObject.name}`}</WithTooltip>
+          </a>,
+          <WithTooltip>{event.getSource()}</WithTooltip>,
+          event.count,
+          <KubeObjectAge key="age" object={event} />,
+          <ReactiveDuration key="last-seen" timestamp={event.lastTimestamp} />,
+        ];
+      }}
+    />
+  );
+
+  if (compact) {
+    return events;
+  }
+
+  return <TabLayout>{events}</TabLayout>;
+});

--- a/src/renderer/components/info-page.module.d.scss.ts
+++ b/src/renderer/components/info-page.module.d.scss.ts
@@ -1,0 +1,5 @@
+declare const classNames: {
+  readonly infoPage: "infoPage";
+  readonly infoMessage: "infoMessage";
+};
+export = classNames;

--- a/src/renderer/components/info-page.module.scss
+++ b/src/renderer/components/info-page.module.scss
@@ -1,0 +1,13 @@
+.infoPage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100%;
+  padding: 32px;
+}
+
+.infoMessage {
+  color: var(--textColorSecondary);
+  font-size: 1.1em;
+  text-align: center;
+}

--- a/src/renderer/components/info-page.tsx
+++ b/src/renderer/components/info-page.tsx
@@ -1,0 +1,17 @@
+import styles from "./info-page.module.scss";
+import stylesInline from "./info-page.module.scss?inline";
+
+export interface InfoPageProps {
+  message?: string;
+}
+
+export function InfoPage({ message }: InfoPageProps) {
+  return (
+    <>
+      <style>{stylesInline}</style>
+      <div className={styles.infoPage}>
+        <p className={styles.infoMessage}>{message}</p>
+      </div>
+    </>
+  );
+}

--- a/src/renderer/components/pie-chart.module.d.scss.ts
+++ b/src/renderer/components/pie-chart.module.d.scss.ts
@@ -1,0 +1,5 @@
+declare const classNames: {
+  readonly chart: "chart";
+  readonly title: "title";
+};
+export = classNames;

--- a/src/renderer/components/pie-chart.module.scss
+++ b/src/renderer/components/pie-chart.module.scss
@@ -1,0 +1,21 @@
+.chart {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.title {
+  margin-bottom: 8px;
+  text-align: center;
+
+  a {
+    color: var(--textColorPrimary);
+    cursor: pointer;
+    font-weight: 500;
+
+    &:hover {
+      color: var(--colorInfo);
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/renderer/components/pie-chart.tsx
+++ b/src/renderer/components/pie-chart.tsx
@@ -1,0 +1,87 @@
+import { Renderer } from "@freelensapp/extensions";
+import { getStatusCategory } from "../api/k8s";
+import styles from "./pie-chart.module.scss";
+import stylesInline from "./pie-chart.module.scss?inline";
+
+import type React from "react";
+
+const getStats = (objects: Renderer.K8sApi.KubeObject[]): [number, number, number, number] => {
+  let ready = 0;
+  let notReady = 0;
+  let inProgress = 0;
+  let unknown = 0;
+
+  for (const object of objects) {
+    switch (getStatusCategory(object)) {
+      case "Ready":
+        ready++;
+        break;
+      case "NotReady":
+        notReady++;
+        break;
+      case "InProgress":
+        inProgress++;
+        break;
+      default:
+        unknown++;
+        break;
+    }
+  }
+
+  return [ready, notReady, inProgress, unknown];
+};
+
+const getPath = (crd: Renderer.K8sApi.CustomResourceDefinition): string => {
+  return crd.spec.names.singular ?? crd.spec.names.plural;
+};
+
+export interface PieChartProps {
+  objects: Renderer.K8sApi.KubeObject[];
+  title: string;
+  crd: Renderer.K8sApi.CustomResourceDefinition;
+}
+
+export function PieChart(props: PieChartProps): React.ReactElement {
+  const { objects, title, crd } = props;
+  const [ready, notReady, inProgress, unknown] = getStats(objects);
+
+  // chart.js typings are not installed in this project, so the host's
+  // PieChartData/ChartData types are degraded and reject the real dataset
+  // shape. Build the value untyped and cast it to the expected PieChartData
+  // type when handing it to the chart component.
+  const chartData = {
+    datasets: [
+      {
+        data: [ready, notReady, inProgress, unknown],
+        backgroundColor: ["#43a047", "#ce3933", "#FF6600", "#3a3a3c"],
+        tooltipLabels: [
+          (percent: string) => `Ready: ${percent}`,
+          (percent: string) => `Not Ready: ${percent}`,
+          (percent: string) => `In Progress: ${percent}`,
+          (percent: string) => `Unknown: ${percent}`,
+        ],
+      },
+    ],
+
+    labels: [`Ready: ${ready}`, `Not Ready: ${notReady}`, `In Progress: ${inProgress}`, `Unknown: ${unknown}`],
+  };
+
+  return (
+    <>
+      <style>{stylesInline}</style>
+      <div className={styles.chart}>
+        <div className={styles.title}>
+          <a
+            onClick={(e) => {
+              e.preventDefault();
+              Renderer.Navigation.navigate({ pathname: getPath(crd) });
+            }}
+          >
+            {title} ({objects.length})
+          </a>
+        </div>
+        <Renderer.Component.PieChart data={chartData as Renderer.Component.PieChartData} />
+      </div>
+    </>
+  );
+}

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -43,6 +43,7 @@ import { ReferenceGrantsPage as ReferenceGrantsPage_v1beta1 } from "./pages/k8s/
 import { TCPRoutesPage as TCPRoutesPage_v1alpha2 } from "./pages/k8s/tcp-routes-page-v1alpha2";
 import { TLSRoutesPage as TLSRoutesPage_v1 } from "./pages/k8s/tls-routes-page-v1";
 import { UDPRoutesPage as UDPRoutesPage_v1alpha2 } from "./pages/k8s/udp-routes-page-v1alpha2";
+import { OverviewPage } from "./pages/overview";
 import { XBackendTrafficPoliciesPage as XBackendTrafficPoliciesPage_v1alpha1 } from "./pages/x-k8s/x-backend-traffic-policies-page-v1alpha1";
 import { XMeshesPage as XMeshesPage_v1alpha1 } from "./pages/x-k8s/xmeshes-page-v1alpha1";
 
@@ -162,6 +163,12 @@ export default class GatewayApiRenderer extends Renderer.LensExtension {
 
   clusterPages = [
     {
+      id: "overview",
+      components: {
+        Page: (props: { extension: Renderer.LensExtension }) => <OverviewPage {...props} />,
+      },
+    },
+    {
       id: "gatewayclass",
       components: {
         Page: createAvailableVersionPage("Gateway Classes", [
@@ -275,6 +282,13 @@ export default class GatewayApiRenderer extends Renderer.LensExtension {
       components: {
         Icon: GatewayApiIcon,
       },
+    },
+    {
+      id: "overview",
+      parentId: "gateway-api",
+      title: "Overview",
+      target: { pageId: "overview" },
+      components: {},
     },
     {
       id: "gatewayclass",

--- a/src/renderer/pages/overview.module.d.scss.ts
+++ b/src/renderer/pages/overview.module.d.scss.ts
@@ -1,0 +1,7 @@
+declare const classNames: {
+  readonly overviewContent: "overviewContent";
+  readonly overviewStatuses: "overviewStatuses";
+  readonly statuses: "statuses";
+  readonly chartColumn: "chartColumn";
+};
+export = classNames;

--- a/src/renderer/pages/overview.module.scss
+++ b/src/renderer/pages/overview.module.scss
@@ -1,0 +1,35 @@
+@use "../vars";
+
+.overviewContent {
+  min-height: 100%;
+  height: 100%;
+  overflow-y: auto;
+
+  header {
+    background: var(--contentColor);
+    position: relative;
+    padding: vars.$padding * 2;
+    padding-bottom: 3em;
+    text-align: center;
+
+    h5 {
+      color: var(--textColorPrimary);
+    }
+  }
+}
+
+.overviewStatuses {
+  background: var(--contentColor);
+}
+
+.statuses {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, 160px);
+  justify-content: space-evenly;
+  grid-gap: 16px;
+  padding: 16px;
+}
+
+.chartColumn {
+  align-self: end;
+}

--- a/src/renderer/pages/overview.tsx
+++ b/src/renderer/pages/overview.tsx
@@ -1,0 +1,153 @@
+import { Common, Renderer } from "@freelensapp/extensions";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  BackendTLSPolicy as BackendTLSPolicy_v1,
+  Gateway as Gateway_v1,
+  GatewayClass as GatewayClass_v1,
+  GRPCRoute as GRPCRoute_v1,
+  HTTPRoute as HTTPRoute_v1,
+  ListenerSet as ListenerSet_v1,
+  TCPRoute as TCPRoute_v1alpha2,
+  TLSRoute as TLSRoute_v1,
+  UDPRoute as UDPRoute_v1alpha2,
+} from "../api/k8s";
+import { XBackendTrafficPolicy as XBackendTrafficPolicy_v1alpha1, XMesh as XMesh_v1alpha1 } from "../api/x-k8s";
+import { GatewayApiEvents } from "../components/gateway-api-events";
+import { InfoPage } from "../components/info-page";
+import { PieChart } from "../components/pie-chart";
+import { observer } from "../observer";
+import styles from "./overview.module.scss";
+import stylesInline from "./overview.module.scss?inline";
+
+const {
+  Component: { NamespaceSelectFilter, TabLayout },
+} = Renderer;
+
+const {
+  Util: { cssNames },
+} = Common;
+
+// Resources whose status can be summarized. ReferenceGrant is omitted because
+// it has no status subresource.
+const resources = [
+  GatewayClass_v1,
+  Gateway_v1,
+  HTTPRoute_v1,
+  GRPCRoute_v1,
+  TCPRoute_v1alpha2,
+  TLSRoute_v1,
+  UDPRoute_v1alpha2,
+  ListenerSet_v1,
+  BackendTLSPolicy_v1,
+  XBackendTrafficPolicy_v1alpha1,
+  XMesh_v1alpha1,
+];
+
+export interface OverviewPageProps {
+  extension?: Renderer.LensExtension;
+}
+
+export const OverviewPage = observer((_props: OverviewPageProps) => {
+  const [crds, setCrds] = useState<Renderer.K8sApi.CustomResourceDefinition[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const watches = useRef<(() => void)[]>([]);
+  const abortController = useRef(new AbortController());
+
+  const getCrd = useCallback(
+    (store: Renderer.K8sApi.KubeObjectStore) => {
+      return crds.find((crd) => crd.spec.names.kind === store.api.kind && crd.spec.group === store.api.apiGroup);
+    },
+    [crds],
+  );
+
+  const getChart = useCallback(
+    (resource: (typeof resources)[number]) => {
+      try {
+        const store = resource.getStore();
+        if (!store) return null;
+        const crd = getCrd(store);
+        if (!crd) return null;
+
+        const items = store.contextItems;
+
+        return (
+          <div key={resource.crd.plural} className={cssNames(styles.chartColumn, "column")} hidden={!items.length}>
+            <PieChart title={resource.crd.title} objects={items} crd={crd} />
+          </div>
+        );
+      } catch (_) {
+        return null;
+      }
+    },
+    [getCrd],
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+    const signal = abortController.current.signal;
+
+    (async () => {
+      const crdStore = Renderer.K8sApi.crdStore;
+      const loadedCrds = (await crdStore.loadAll()) || [];
+      if (isMounted) setCrds(loadedCrds);
+
+      const namespaceStore = Renderer.K8sApi.namespaceStore;
+      await namespaceStore.loadAll({ namespaces: [], reqInit: { signal } });
+      watches.current.push(namespaceStore.subscribe());
+
+      const namespaces = namespaceStore.items.map((ns) => ns.getName());
+
+      for (const resource of resources) {
+        try {
+          const store = resource.getStore();
+          if (!store) continue;
+          await store.loadAll({ namespaces, reqInit: { signal } });
+          watches.current.push(store.subscribe());
+        } catch (_) {
+          continue;
+        }
+      }
+
+      try {
+        const eventStore = Renderer.K8sApi.eventStore;
+        await eventStore.loadAll({ namespaces, reqInit: { signal } });
+        watches.current.push(eventStore.subscribe());
+      } catch (_) {
+        // events are best-effort
+      }
+
+      if (isMounted) setLoaded(true);
+    })();
+
+    return () => {
+      isMounted = false;
+      abortController.current.abort();
+      watches.current.forEach((unsubscribe) => unsubscribe());
+      watches.current = [];
+    };
+  }, []);
+
+  if (!loaded && crds.length === 0) {
+    return <InfoPage message="Loading Gateway API resources..." />;
+  }
+
+  return (
+    <>
+      <style>{stylesInline}</style>
+      <TabLayout>
+        <div className={styles.overviewContent}>
+          <header>
+            <h5>Gateway API Overview</h5>
+            <NamespaceSelectFilter id="gateway-api-overview-namespace-select-filter-input" />
+          </header>
+
+          <div className={styles.overviewStatuses}>
+            <div className={styles.statuses}>{resources.map((resource) => getChart(resource))}</div>
+          </div>
+
+          <GatewayApiEvents compact compactLimit={100} />
+        </div>
+      </TabLayout>
+    </>
+  );
+});


### PR DESCRIPTION
Implements an overview page for Gateway API resources, modelled after the freelens-fluxcd-extension overview.

- Status pie charts per resource type (Ready / Not Ready / In Progress / Unknown), derived from each resource's conditions and reason-aware for transient states.
- Filtered Gateway API events list.
- Registered as the first cluster page and menu entry under Gateway API.

Closes #38.

Generated with [Claude Code](https://claude.ai/code)