### PR TITLE
Show nginx gateway fabric policies in Gateway detail view

### DIFF
--- a/src/renderer/api/nginx/client-settings-policy-v1alpha1.ts
+++ b/src/renderer/api/nginx/client-settings-policy-v1alpha1.ts
@@ -1,0 +1,51 @@
+import { Renderer } from "@freelensapp/extensions";
+import { type LocalPolicyTargetReference } from "../k8s/backend-tls-policy-v1";
+import { type GatewayKubeObjectCRD, type PolicyStatus } from "../k8s/types";
+
+export interface ClientKeepAliveTimeout {
+  server?: string;
+  header?: string;
+}
+
+export interface ClientKeepAlive {
+  requests?: number;
+  time?: string;
+  timeout?: ClientKeepAliveTimeout;
+  minTimeout?: string;
+}
+
+export interface ClientBody {
+  maxSize?: string;
+  timeout?: string;
+}
+
+export interface ClientSettingsPolicySpec {
+  targetRef: LocalPolicyTargetReference;
+  body?: ClientBody;
+  keepAlive?: ClientKeepAlive;
+}
+
+export interface ClientSettingsPolicyStatus extends PolicyStatus {}
+
+export class ClientSettingsPolicy extends Renderer.K8sApi.LensExtensionKubeObject<
+  Renderer.K8sApi.KubeObjectMetadata,
+  ClientSettingsPolicyStatus,
+  ClientSettingsPolicySpec
+> {
+  static readonly kind = "ClientSettingsPolicy";
+  static readonly namespaced = true;
+  static readonly apiBase = "/apis/gateway.nginx.org/v1alpha1/clientsettingspolicies";
+  static readonly crd: GatewayKubeObjectCRD = {
+    apiVersions: ["gateway.nginx.org/v1alpha1"],
+    plural: "clientsettingspolicies",
+    singular: "clientsettingspolicy",
+    shortNames: [],
+    title: "Client Settings Policies",
+  };
+}
+
+export class ClientSettingsPolicyApi extends Renderer.K8sApi.KubeApi<ClientSettingsPolicy> {}
+export class ClientSettingsPolicyStore extends Renderer.K8sApi.KubeObjectStore<
+  ClientSettingsPolicy,
+  ClientSettingsPolicyApi
+> {}

--- a/src/renderer/api/nginx/index.ts
+++ b/src/renderer/api/nginx/index.ts
@@ -1,0 +1,36 @@
+import {
+  ClientSettingsPolicy as ClientSettingsPolicy_v1alpha1,
+  ClientSettingsPolicyApi as ClientSettingsPolicyApi_v1alpha1,
+  ClientSettingsPolicyStore as ClientSettingsPolicyStore_v1alpha1,
+} from "./client-settings-policy-v1alpha1";
+import {
+  ProxySettingsPolicy as ProxySettingsPolicy_v1alpha1,
+  ProxySettingsPolicyApi as ProxySettingsPolicyApi_v1alpha1,
+  ProxySettingsPolicyStore as ProxySettingsPolicyStore_v1alpha1,
+} from "./proxy-settings-policy-v1alpha1";
+import {
+  UpstreamSettingsPolicy as UpstreamSettingsPolicy_v1alpha1,
+  UpstreamSettingsPolicyApi as UpstreamSettingsPolicyApi_v1alpha1,
+  UpstreamSettingsPolicyStore as UpstreamSettingsPolicyStore_v1alpha1,
+} from "./upstream-settings-policy-v1alpha1";
+
+export {
+  ClientSettingsPolicy_v1alpha1,
+  ClientSettingsPolicy_v1alpha1 as ClientSettingsPolicy,
+  ClientSettingsPolicyApi_v1alpha1,
+  ClientSettingsPolicyApi_v1alpha1 as ClientSettingsPolicyApi,
+  ClientSettingsPolicyStore_v1alpha1,
+  ClientSettingsPolicyStore_v1alpha1 as ClientSettingsPolicyStore,
+  ProxySettingsPolicy_v1alpha1,
+  ProxySettingsPolicy_v1alpha1 as ProxySettingsPolicy,
+  ProxySettingsPolicyApi_v1alpha1,
+  ProxySettingsPolicyApi_v1alpha1 as ProxySettingsPolicyApi,
+  ProxySettingsPolicyStore_v1alpha1,
+  ProxySettingsPolicyStore_v1alpha1 as ProxySettingsPolicyStore,
+  UpstreamSettingsPolicy_v1alpha1,
+  UpstreamSettingsPolicy_v1alpha1 as UpstreamSettingsPolicy,
+  UpstreamSettingsPolicyApi_v1alpha1,
+  UpstreamSettingsPolicyApi_v1alpha1 as UpstreamSettingsPolicyApi,
+  UpstreamSettingsPolicyStore_v1alpha1,
+  UpstreamSettingsPolicyStore_v1alpha1 as UpstreamSettingsPolicyStore,
+};

--- a/src/renderer/api/nginx/proxy-settings-policy-v1alpha1.ts
+++ b/src/renderer/api/nginx/proxy-settings-policy-v1alpha1.ts
@@ -1,0 +1,52 @@
+import { Renderer } from "@freelensapp/extensions";
+import { type LocalPolicyTargetReference } from "../k8s/backend-tls-policy-v1";
+import { type GatewayKubeObjectCRD, type PolicyStatus } from "../k8s/types";
+
+export interface ProxyBuffers {
+  number?: number;
+  size?: string;
+}
+
+export interface ProxyBuffering {
+  disable?: boolean;
+  bufferSize?: string;
+  buffers?: ProxyBuffers;
+  busyBuffersSize?: string;
+}
+
+export interface ProxyTimeout {
+  connect?: string;
+  read?: string;
+  send?: string;
+}
+
+export interface ProxySettingsPolicySpec {
+  targetRefs: LocalPolicyTargetReference[];
+  buffering?: ProxyBuffering;
+  timeout?: ProxyTimeout;
+}
+
+export interface ProxySettingsPolicyStatus extends PolicyStatus {}
+
+export class ProxySettingsPolicy extends Renderer.K8sApi.LensExtensionKubeObject<
+  Renderer.K8sApi.KubeObjectMetadata,
+  ProxySettingsPolicyStatus,
+  ProxySettingsPolicySpec
+> {
+  static readonly kind = "ProxySettingsPolicy";
+  static readonly namespaced = true;
+  static readonly apiBase = "/apis/gateway.nginx.org/v1alpha1/proxysettingspolicies";
+  static readonly crd: GatewayKubeObjectCRD = {
+    apiVersions: ["gateway.nginx.org/v1alpha1"],
+    plural: "proxysettingspolicies",
+    singular: "proxysettingspolicy",
+    shortNames: [],
+    title: "Proxy Settings Policies",
+  };
+}
+
+export class ProxySettingsPolicyApi extends Renderer.K8sApi.KubeApi<ProxySettingsPolicy> {}
+export class ProxySettingsPolicyStore extends Renderer.K8sApi.KubeObjectStore<
+  ProxySettingsPolicy,
+  ProxySettingsPolicyApi
+> {}

--- a/src/renderer/api/nginx/upstream-settings-policy-v1alpha1.ts
+++ b/src/renderer/api/nginx/upstream-settings-policy-v1alpha1.ts
@@ -1,0 +1,43 @@
+import { Renderer } from "@freelensapp/extensions";
+import { type LocalPolicyTargetReference } from "../k8s/backend-tls-policy-v1";
+import { type GatewayKubeObjectCRD, type PolicyStatus } from "../k8s/types";
+
+export interface UpstreamKeepAlive {
+  connections?: number;
+  requests?: number;
+  time?: string;
+  timeout?: string;
+}
+
+export interface UpstreamSettingsPolicySpec {
+  targetRefs: LocalPolicyTargetReference[];
+  zoneSize?: string;
+  keepAlive?: UpstreamKeepAlive;
+  loadBalancingMethod?: string;
+  hashMethodKey?: string;
+}
+
+export interface UpstreamSettingsPolicyStatus extends PolicyStatus {}
+
+export class UpstreamSettingsPolicy extends Renderer.K8sApi.LensExtensionKubeObject<
+  Renderer.K8sApi.KubeObjectMetadata,
+  UpstreamSettingsPolicyStatus,
+  UpstreamSettingsPolicySpec
+> {
+  static readonly kind = "UpstreamSettingsPolicy";
+  static readonly namespaced = true;
+  static readonly apiBase = "/apis/gateway.nginx.org/v1alpha1/upstreamsettingspolicies";
+  static readonly crd: GatewayKubeObjectCRD = {
+    apiVersions: ["gateway.nginx.org/v1alpha1"],
+    plural: "upstreamsettingspolicies",
+    singular: "upstreamsettingspolicy",
+    shortNames: [],
+    title: "Upstream Settings Policies",
+  };
+}
+
+export class UpstreamSettingsPolicyApi extends Renderer.K8sApi.KubeApi<UpstreamSettingsPolicy> {}
+export class UpstreamSettingsPolicyStore extends Renderer.K8sApi.KubeObjectStore<
+  UpstreamSettingsPolicy,
+  UpstreamSettingsPolicyApi
+> {}

--- a/src/renderer/details/k8s/gateway-details-v1.tsx
+++ b/src/renderer/details/k8s/gateway-details-v1.tsx
@@ -1,10 +1,22 @@
 import { Renderer } from "@freelensapp/extensions";
+import React from "react";
 import { Gateway } from "../../api/k8s";
+import {
+  ClientSettingsPolicy,
+  ClientSettingsPolicyApi,
+  ProxySettingsPolicy,
+  ProxySettingsPolicyApi,
+  UpstreamSettingsPolicy,
+  UpstreamSettingsPolicyApi,
+} from "../../api/nginx";
 import { observer } from "../../observer";
 import styles from "./common.module.scss";
 import stylesInline from "./common.module.scss?inline";
 
 import type { GatewaySpecAddress, ListenerStatus } from "../../api/k8s/gateway-v1";
+import type { ClientBody, ClientKeepAlive } from "../../api/nginx/client-settings-policy-v1alpha1";
+import type { ProxyBuffering, ProxyTimeout } from "../../api/nginx/proxy-settings-policy-v1alpha1";
+import type { UpstreamKeepAlive } from "../../api/nginx/upstream-settings-policy-v1alpha1";
 
 const {
   Component: { BadgeBoolean, DrawerItem, DrawerItemLabels, DrawerTitle, Icon, LinkToObject, LinkToSecret },
@@ -19,6 +31,161 @@ function isAccepted(object: Gateway): boolean {
 function isProgrammed(object: Gateway): boolean {
   return (object.status?.conditions ?? []).some(
     (condition) => condition?.type === "Programmed" && condition?.status === "True",
+  );
+}
+
+function useClientSettingsPolicies(object: Gateway): ClientSettingsPolicy[] {
+  const [items, setItems] = React.useState<ClientSettingsPolicy[]>([]);
+
+  React.useEffect(() => {
+    const api = new ClientSettingsPolicyApi({ objectConstructor: ClientSettingsPolicy });
+
+    api
+      .list({ namespace: object.getNs() })
+      .then((list) => {
+        const filtered = (list ?? []).filter((policy) => {
+          const targetRef = policy.spec?.targetRef;
+
+          if (!targetRef) return false;
+
+          const group = targetRef.group || "gateway.networking.k8s.io";
+
+          return group === "gateway.networking.k8s.io" && targetRef.kind === "Gateway" && targetRef.name === object.getName();
+        });
+
+        setItems(filtered);
+      })
+      .catch(() => setItems([]));
+  }, [object.getName(), object.getNs()]);
+
+  return items;
+}
+
+function useProxySettingsPolicies(object: Gateway): ProxySettingsPolicy[] {
+  const [items, setItems] = React.useState<ProxySettingsPolicy[]>([]);
+
+  React.useEffect(() => {
+    const api = new ProxySettingsPolicyApi({ objectConstructor: ProxySettingsPolicy });
+
+    api
+      .list({ namespace: object.getNs() })
+      .then((list) => {
+        const filtered = (list ?? []).filter((policy) => {
+          const targetRefs = policy.spec?.targetRefs ?? [];
+
+          return targetRefs.some((targetRef) => {
+            const group = targetRef.group || "gateway.networking.k8s.io";
+
+            return group === "gateway.networking.k8s.io" && targetRef.kind === "Gateway" && targetRef.name === object.getName();
+          });
+        });
+
+        setItems(filtered);
+      })
+      .catch(() => setItems([]));
+  }, [object.getName(), object.getNs()]);
+
+  return items;
+}
+
+function useUpstreamSettingsPolicies(object: Gateway): UpstreamSettingsPolicy[] {
+  const [items, setItems] = React.useState<UpstreamSettingsPolicy[]>([]);
+
+  React.useEffect(() => {
+    const api = new UpstreamSettingsPolicyApi({ objectConstructor: UpstreamSettingsPolicy });
+
+    api
+      .list({ namespace: object.getNs() })
+      .then((list) => {
+        const filtered = (list ?? []).filter((policy) => {
+          const targetRefs = policy.spec?.targetRefs ?? [];
+
+          return targetRefs.some((targetRef) => {
+            const group = targetRef.group || "gateway.networking.k8s.io";
+
+            return group === "gateway.networking.k8s.io" && targetRef.kind === "Gateway" && targetRef.name === object.getName();
+          });
+        });
+
+        setItems(filtered);
+      })
+      .catch(() => setItems([]));
+  }, [object.getName(), object.getNs()]);
+
+  return items;
+}
+
+function renderClientBody(body: ClientBody | undefined) {
+  if (!body) return null;
+
+  return (
+    <>
+      <DrawerItem name="Body Max Size">{body.maxSize ?? "-"}</DrawerItem>
+      <DrawerItem name="Body Timeout">{body.timeout ?? "-"}</DrawerItem>
+    </>
+  );
+}
+
+function renderClientKeepAlive(keepAlive: ClientKeepAlive | undefined) {
+  if (!keepAlive) return null;
+
+  return (
+    <>
+      <DrawerItem name="Keep-Alive Requests">{keepAlive.requests ?? "-"}</DrawerItem>
+      <DrawerItem name="Keep-Alive Time">{keepAlive.time ?? "-"}</DrawerItem>
+      <DrawerItem name="Keep-Alive Min Timeout">{keepAlive.minTimeout ?? "-"}</DrawerItem>
+      {keepAlive.timeout && (
+        <>
+          <DrawerItem name="Keep-Alive Timeout Server">{keepAlive.timeout.server ?? "-"}</DrawerItem>
+          <DrawerItem name="Keep-Alive Timeout Header">{keepAlive.timeout.header ?? "-"}</DrawerItem>
+        </>
+      )}
+    </>
+  );
+}
+
+function renderProxyBuffering(buffering: ProxyBuffering | undefined) {
+  if (!buffering) return null;
+
+  return (
+    <>
+      <DrawerItem name="Buffering Disabled">
+        <BadgeBoolean value={buffering.disable ?? false} />
+      </DrawerItem>
+      <DrawerItem name="Buffer Size">{buffering.bufferSize ?? "-"}</DrawerItem>
+      {buffering.buffers && (
+        <>
+          <DrawerItem name="Buffers Number">{buffering.buffers.number ?? "-"}</DrawerItem>
+          <DrawerItem name="Buffers Size">{buffering.buffers.size ?? "-"}</DrawerItem>
+        </>
+      )}
+      <DrawerItem name="Busy Buffers Size">{buffering.busyBuffersSize ?? "-"}</DrawerItem>
+    </>
+  );
+}
+
+function renderProxyTimeout(timeout: ProxyTimeout | undefined) {
+  if (!timeout) return null;
+
+  return (
+    <>
+      <DrawerItem name="Timeout Connect">{timeout.connect ?? "-"}</DrawerItem>
+      <DrawerItem name="Timeout Read">{timeout.read ?? "-"}</DrawerItem>
+      <DrawerItem name="Timeout Send">{timeout.send ?? "-"}</DrawerItem>
+    </>
+  );
+}
+
+function renderUpstreamKeepAlive(keepAlive: UpstreamKeepAlive | undefined) {
+  if (!keepAlive) return null;
+
+  return (
+    <>
+      <DrawerItem name="Keep-Alive Connections">{keepAlive.connections ?? "-"}</DrawerItem>
+      <DrawerItem name="Keep-Alive Requests">{keepAlive.requests ?? "-"}</DrawerItem>
+      <DrawerItem name="Keep-Alive Time">{keepAlive.time ?? "-"}</DrawerItem>
+      <DrawerItem name="Keep-Alive Timeout">{keepAlive.timeout ?? "-"}</DrawerItem>
+    </>
   );
 }
 
@@ -73,6 +240,9 @@ export const GatewayDetails = observer((props: Renderer.Component.KubeObjectDeta
   const frontendValidation = object.spec?.tls?.frontend?.default?.validation;
   const frontendPerPort = object.spec?.tls?.frontend?.perPort ?? [];
   const listenerStatuses = (object.status?.listeners ?? []) as ListenerStatus[];
+  const clientPolicies = useClientSettingsPolicies(object);
+  const proxyPolicies = useProxySettingsPolicies(object);
+  const upstreamPolicies = useUpstreamSettingsPolicies(object);
 
   return (
     <>
@@ -222,6 +392,44 @@ export const GatewayDetails = observer((props: Renderer.Component.KubeObjectDeta
               </DrawerItem>
             </div>
           ))}
+
+        {clientPolicies.length > 0 && (
+          <>
+            {clientPolicies.map((policy) => (
+              <div key={`csp-${policy.getName()}`}>
+                <DrawerTitle>Client Settings Policy: {policy.getName()}</DrawerTitle>
+                {renderClientBody(policy.spec?.body)}
+                {renderClientKeepAlive(policy.spec?.keepAlive)}
+              </div>
+            ))}
+          </>
+        )}
+
+        {proxyPolicies.length > 0 && (
+          <>
+            {proxyPolicies.map((policy) => (
+              <div key={`psp-${policy.getName()}`}>
+                <DrawerTitle>Proxy Settings Policy: {policy.getName()}</DrawerTitle>
+                {renderProxyBuffering(policy.spec?.buffering)}
+                {renderProxyTimeout(policy.spec?.timeout)}
+              </div>
+            ))}
+          </>
+        )}
+
+        {upstreamPolicies.length > 0 && (
+          <>
+            {upstreamPolicies.map((policy) => (
+              <div key={`usp-${policy.getName()}`}>
+                <DrawerTitle>Upstream Settings Policy: {policy.getName()}</DrawerTitle>
+                <DrawerItem name="Zone Size">{policy.spec?.zoneSize ?? "-"}</DrawerItem>
+                <DrawerItem name="Load Balancing Method">{policy.spec?.loadBalancingMethod ?? "-"}</DrawerItem>
+                <DrawerItem name="Hash Method Key">{policy.spec?.hashMethodKey ?? "-"}</DrawerItem>
+                {renderUpstreamKeepAlive(policy.spec?.keepAlive)}
+              </div>
+            ))}
+          </>
+        )}
       </div>
     </>
   );

--- a/src/renderer/details/nginx/client-settings-policy-details-v1alpha1.tsx
+++ b/src/renderer/details/nginx/client-settings-policy-details-v1alpha1.tsx
@@ -1,0 +1,49 @@
+import { Renderer } from "@freelensapp/extensions";
+import { ClientSettingsPolicy } from "../../api/nginx";
+import { observer } from "../../observer";
+import styles from "../k8s/common.module.scss";
+import stylesInline from "../k8s/common.module.scss?inline";
+
+const {
+  Component: { DrawerItem, DrawerTitle },
+} = Renderer;
+
+export const ClientSettingsPolicyDetails = observer(
+  (props: Renderer.Component.KubeObjectDetailsProps<ClientSettingsPolicy>) => {
+    const { object } = props;
+    const body = object.spec?.body;
+    const keepAlive = object.spec?.keepAlive;
+
+    return (
+      <>
+        <style>{stylesInline}</style>
+        <div className={styles.details}>
+          {body && (
+            <>
+              <DrawerTitle>Body</DrawerTitle>
+              <DrawerItem name="Max Size">{body.maxSize ?? "-"}</DrawerItem>
+              <DrawerItem name="Timeout">{body.timeout ?? "-"}</DrawerItem>
+            </>
+          )}
+
+          {keepAlive && (
+            <>
+              <DrawerTitle>Keep-Alive</DrawerTitle>
+              <DrawerItem name="Requests">{keepAlive.requests ?? "-"}</DrawerItem>
+              <DrawerItem name="Time">{keepAlive.time ?? "-"}</DrawerItem>
+              <DrawerItem name="Min Timeout">{keepAlive.minTimeout ?? "-"}</DrawerItem>
+              {keepAlive.timeout && (
+                <>
+                  <DrawerItem name="Timeout Server">{keepAlive.timeout.server ?? "-"}</DrawerItem>
+                  <DrawerItem name="Timeout Header">{keepAlive.timeout.header ?? "-"}</DrawerItem>
+                </>
+              )}
+            </>
+          )}
+
+          {!body && !keepAlive && <DrawerItem name="Spec">No settings configured</DrawerItem>}
+        </div>
+      </>
+    );
+  },
+);

--- a/src/renderer/details/nginx/index.ts
+++ b/src/renderer/details/nginx/index.ts
@@ -1,0 +1,7 @@
+import { ClientSettingsPolicyDetails as ClientSettingsPolicyDetails_v1alpha1 } from "./client-settings-policy-details-v1alpha1";
+import { ProxySettingsPolicyDetails as ProxySettingsPolicyDetails_v1alpha1 } from "./proxy-settings-policy-details-v1alpha1";
+
+export { ClientSettingsPolicyDetails_v1alpha1, ProxySettingsPolicyDetails_v1alpha1 };
+
+export const ClientSettingsPolicyDetails = ClientSettingsPolicyDetails_v1alpha1;
+export const ProxySettingsPolicyDetails = ProxySettingsPolicyDetails_v1alpha1;

--- a/src/renderer/details/nginx/proxy-settings-policy-details-v1alpha1.tsx
+++ b/src/renderer/details/nginx/proxy-settings-policy-details-v1alpha1.tsx
@@ -1,0 +1,52 @@
+import { Renderer } from "@freelensapp/extensions";
+import { ProxySettingsPolicy } from "../../api/nginx";
+import { observer } from "../../observer";
+import styles from "../k8s/common.module.scss";
+import stylesInline from "../k8s/common.module.scss?inline";
+
+const {
+  Component: { BadgeBoolean, DrawerItem, DrawerTitle },
+} = Renderer;
+
+export const ProxySettingsPolicyDetails = observer(
+  (props: Renderer.Component.KubeObjectDetailsProps<ProxySettingsPolicy>) => {
+    const { object } = props;
+    const buffering = object.spec?.buffering;
+    const timeout = object.spec?.timeout;
+
+    return (
+      <>
+        <style>{stylesInline}</style>
+        <div className={styles.details}>
+          {buffering && (
+            <>
+              <DrawerTitle>Buffering</DrawerTitle>
+              <DrawerItem name="Disabled">
+                <BadgeBoolean value={buffering.disable ?? false} />
+              </DrawerItem>
+              <DrawerItem name="Buffer Size">{buffering.bufferSize ?? "-"}</DrawerItem>
+              {buffering.buffers && (
+                <>
+                  <DrawerItem name="Buffers Number">{buffering.buffers.number ?? "-"}</DrawerItem>
+                  <DrawerItem name="Buffers Size">{buffering.buffers.size ?? "-"}</DrawerItem>
+                </>
+              )}
+              <DrawerItem name="Busy Buffers Size">{buffering.busyBuffersSize ?? "-"}</DrawerItem>
+            </>
+          )}
+
+          {timeout && (
+            <>
+              <DrawerTitle>Timeout</DrawerTitle>
+              <DrawerItem name="Connect">{timeout.connect ?? "-"}</DrawerItem>
+              <DrawerItem name="Read">{timeout.read ?? "-"}</DrawerItem>
+              <DrawerItem name="Send">{timeout.send ?? "-"}</DrawerItem>
+            </>
+          )}
+
+          {!buffering && !timeout && <DrawerItem name="Spec">No settings configured</DrawerItem>}
+        </div>
+      </>
+    );
+  },
+);

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -17,6 +17,9 @@ import { TLSRoute as TLSRoute_v1 } from "./api/k8s/tls-route-v1";
 import { UDPRoute as UDPRoute_v1alpha2 } from "./api/k8s/udp-route-v1alpha2";
 import { XBackendTrafficPolicy as XBackendTrafficPolicy_v1alpha1 } from "./api/x-k8s/x-backend-traffic-policy-v1alpha1";
 import { XMesh as XMesh_v1alpha1 } from "./api/x-k8s/xmesh-v1alpha1";
+import { ClientSettingsPolicy as ClientSettingsPolicy_v1alpha1 } from "./api/nginx/client-settings-policy-v1alpha1";
+import { ProxySettingsPolicy as ProxySettingsPolicy_v1alpha1 } from "./api/nginx/proxy-settings-policy-v1alpha1";
+import { UpstreamSettingsPolicy as UpstreamSettingsPolicy_v1alpha1 } from "./api/nginx/upstream-settings-policy-v1alpha1";
 import { createAvailableVersionPage } from "./components/available-version";
 import { BackendTLSPolicyDetails as BackendTLSPolicyDetails_v1 } from "./details/k8s/backend-tls-policy-details-v1";
 import { GatewayClassDetails as GatewayClassDetails_v1 } from "./details/k8s/gateway-class-details-v1";
@@ -157,6 +160,30 @@ export default class GatewayApiRenderer extends Renderer.LensExtension {
       priority: 10,
       components: {
         Details: (props: Renderer.Component.KubeObjectDetailsProps<any>) => <XMeshDetails_v1alpha1 {...props} />,
+      },
+    },
+    {
+      kind: ClientSettingsPolicy_v1alpha1.kind,
+      apiVersions: ClientSettingsPolicy_v1alpha1.crd.apiVersions,
+      priority: 10,
+      components: {
+        Details: () => null,
+      },
+    },
+    {
+      kind: ProxySettingsPolicy_v1alpha1.kind,
+      apiVersions: ProxySettingsPolicy_v1alpha1.crd.apiVersions,
+      priority: 10,
+      components: {
+        Details: () => null,
+      },
+    },
+    {
+      kind: UpstreamSettingsPolicy_v1alpha1.kind,
+      apiVersions: UpstreamSettingsPolicy_v1alpha1.crd.apiVersions,
+      priority: 10,
+      components: {
+        Details: () => null,
       },
     },
   ];

--- a/src/renderer/pages/nginx/client-settings-policies-page-v1alpha1.module.d.scss.ts
+++ b/src/renderer/pages/nginx/client-settings-policies-page-v1alpha1.module.d.scss.ts
@@ -1,0 +1,8 @@
+declare const classNames: {
+  readonly page: "page";
+  readonly tableCell: "tableCell";
+  readonly name: "name";
+  readonly namespace: "namespace";
+  readonly age: "age";
+};
+export = classNames;

--- a/src/renderer/pages/nginx/client-settings-policies-page-v1alpha1.module.scss
+++ b/src/renderer/pages/nginx/client-settings-policies-page-v1alpha1.module.scss
@@ -1,0 +1,15 @@
+.page {
+  :global(.TableCell) {
+    &.name {
+      flex-grow: 1.3;
+    }
+
+    &.namespace {
+      flex-grow: 1;
+    }
+
+    &.age {
+      flex-grow: 0.3;
+    }
+  }
+}

--- a/src/renderer/pages/nginx/client-settings-policies-page-v1alpha1.tsx
+++ b/src/renderer/pages/nginx/client-settings-policies-page-v1alpha1.tsx
@@ -1,0 +1,45 @@
+import { Renderer } from "@freelensapp/extensions";
+import { ClientSettingsPolicy } from "../../api/nginx";
+import { withErrorPage } from "../../components/error-page";
+import { observer } from "../../observer";
+import { type GatewayPageProps, namespaceCell } from "../k8s/shared";
+import styles from "./client-settings-policies-page-v1alpha1.module.scss";
+import stylesInline from "./client-settings-policies-page-v1alpha1.module.scss?inline";
+
+const {
+  Component: { KubeObjectAge, KubeObjectListLayout, WithTooltip },
+} = Renderer;
+
+export const ClientSettingsPoliciesPage = observer((props: GatewayPageProps) =>
+  withErrorPage(props, () => {
+    const store = ClientSettingsPolicy.getStore<ClientSettingsPolicy>();
+
+    return (
+      <>
+        <style>{stylesInline}</style>
+        <KubeObjectListLayout<ClientSettingsPolicy, any>
+          tableId={`${ClientSettingsPolicy.crd.plural}Table`}
+          className={styles.page}
+          store={store}
+          sortingCallbacks={{
+            name: (item: ClientSettingsPolicy) => item.getName(),
+            namespace: (item: ClientSettingsPolicy) => item.getNs() ?? "",
+            age: (item: ClientSettingsPolicy) => item.getCreationTimestamp(),
+          }}
+          searchFilters={[(item: ClientSettingsPolicy) => item.getSearchFields()]}
+          renderHeaderTitle={ClientSettingsPolicy.crd.title}
+          renderTableHeader={[
+            { title: "Name", sortBy: "name", className: styles.name },
+            { title: "Namespace", sortBy: "namespace", className: styles.namespace },
+            { title: "Age", sortBy: "age", className: styles.age },
+          ]}
+          renderTableContents={(item: ClientSettingsPolicy) => [
+            <WithTooltip>{item.getName()}</WithTooltip>,
+            namespaceCell(item.getNs()),
+            <KubeObjectAge object={item} key="age" />,
+          ]}
+        />
+      </>
+    );
+  }),
+);

--- a/src/renderer/pages/nginx/index.ts
+++ b/src/renderer/pages/nginx/index.ts
@@ -1,0 +1,7 @@
+import { ClientSettingsPoliciesPage as ClientSettingsPoliciesPage_v1alpha1 } from "./client-settings-policies-page-v1alpha1";
+import { ProxySettingsPoliciesPage as ProxySettingsPoliciesPage_v1alpha1 } from "./proxy-settings-policies-page-v1alpha1";
+
+export { ClientSettingsPoliciesPage_v1alpha1, ProxySettingsPoliciesPage_v1alpha1 };
+
+export const ClientSettingsPoliciesPage = ClientSettingsPoliciesPage_v1alpha1;
+export const ProxySettingsPoliciesPage = ProxySettingsPoliciesPage_v1alpha1;

--- a/src/renderer/pages/nginx/proxy-settings-policies-page-v1alpha1.module.d.scss.ts
+++ b/src/renderer/pages/nginx/proxy-settings-policies-page-v1alpha1.module.d.scss.ts
@@ -1,0 +1,8 @@
+declare const classNames: {
+  readonly page: "page";
+  readonly tableCell: "tableCell";
+  readonly name: "name";
+  readonly namespace: "namespace";
+  readonly age: "age";
+};
+export = classNames;

--- a/src/renderer/pages/nginx/proxy-settings-policies-page-v1alpha1.module.scss
+++ b/src/renderer/pages/nginx/proxy-settings-policies-page-v1alpha1.module.scss
@@ -1,0 +1,15 @@
+.page {
+  :global(.TableCell) {
+    &.name {
+      flex-grow: 1.3;
+    }
+
+    &.namespace {
+      flex-grow: 1;
+    }
+
+    &.age {
+      flex-grow: 0.3;
+    }
+  }
+}

--- a/src/renderer/pages/nginx/proxy-settings-policies-page-v1alpha1.tsx
+++ b/src/renderer/pages/nginx/proxy-settings-policies-page-v1alpha1.tsx
@@ -1,0 +1,45 @@
+import { Renderer } from "@freelensapp/extensions";
+import { ProxySettingsPolicy } from "../../api/nginx";
+import { withErrorPage } from "../../components/error-page";
+import { observer } from "../../observer";
+import { type GatewayPageProps, namespaceCell } from "../k8s/shared";
+import styles from "./proxy-settings-policies-page-v1alpha1.module.scss";
+import stylesInline from "./proxy-settings-policies-page-v1alpha1.module.scss?inline";
+
+const {
+  Component: { KubeObjectAge, KubeObjectListLayout, WithTooltip },
+} = Renderer;
+
+export const ProxySettingsPoliciesPage = observer((props: GatewayPageProps) =>
+  withErrorPage(props, () => {
+    const store = ProxySettingsPolicy.getStore<ProxySettingsPolicy>();
+
+    return (
+      <>
+        <style>{stylesInline}</style>
+        <KubeObjectListLayout<ProxySettingsPolicy, any>
+          tableId={`${ProxySettingsPolicy.crd.plural}Table`}
+          className={styles.page}
+          store={store}
+          sortingCallbacks={{
+            name: (item: ProxySettingsPolicy) => item.getName(),
+            namespace: (item: ProxySettingsPolicy) => item.getNs() ?? "",
+            age: (item: ProxySettingsPolicy) => item.getCreationTimestamp(),
+          }}
+          searchFilters={[(item: ProxySettingsPolicy) => item.getSearchFields()]}
+          renderHeaderTitle={ProxySettingsPolicy.crd.title}
+          renderTableHeader={[
+            { title: "Name", sortBy: "name", className: styles.name },
+            { title: "Namespace", sortBy: "namespace", className: styles.namespace },
+            { title: "Age", sortBy: "age", className: styles.age },
+          ]}
+          renderTableContents={(item: ProxySettingsPolicy) => [
+            <WithTooltip>{item.getName()}</WithTooltip>,
+            namespaceCell(item.getNs()),
+            <KubeObjectAge object={item} key="age" />,
+          ]}
+        />
+      </>
+    );
+  }),
+);


### PR DESCRIPTION
Add support for `gateway.nginx.org/v1alpha1` ClientSettingsPolicy, ProxySettingsPolicy, and UpstreamSettingsPolicy CRDs.

When viewing a Gateway detail, the extension fetches policies from the same namespace that target the gateway and displays their spec fields (excluding targetRef/targetRefs):

- **ClientSettingsPolicy**: body (maxSize, timeout), keepAlive (requests, time, minTimeout, timeout server/header)
- **ProxySettingsPolicy**: buffering (disable, bufferSize, buffers, busyBuffersSize), timeout (connect, read, send)
- **UpstreamSettingsPolicy**: zoneSize, loadBalancingMethod, hashMethodKey, keepAlive (connections, requests, time, timeout)

Other gateways(withous such settings) are fine, tested with aws alb controller's.

Policies are fetched via `KubeApi.list()` on component mount, so they appear regardless of whether the CRD store has been pre-populated by a list page.