### PR TITLE
Make builds deterministic with a globalExternals plugin

### DIFF
--- a/.github/workflows/biome-migrate.yaml
+++ b/.github/workflows/biome-migrate.yaml
@@ -29,7 +29,7 @@ jobs:
     if: github.event_name != 'issue_comment' || (startsWith(github.event.issue.title, 'Automated biome migrate') && contains(github.event.comment.body, '/rerun'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GH_TOKEN }}
 
@@ -47,7 +47,7 @@ jobs:
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
 
       - name: Use pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.pnpm_cache_dir }}
           key: ubuntu-24.04-arm-node-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup node
         uses: actions/setup-node@v6
@@ -37,7 +37,7 @@ jobs:
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
 
       - name: Use pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.pnpm_cache_dir }}
           key: ubuntu-24.04-arm-node-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -54,6 +54,18 @@ jobs:
         run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
 
       - name: Build packages
+        id: build-packages
+        run: pnpm --color=always --stream build:production
+        continue-on-error: true
+
+      - name: Build packages (retry)
+        id: build-packages-2
+        if: steps.build-packages.outcome == 'failure'
+        run: pnpm --color=always --stream build:production
+        continue-on-error: true
+
+      - name: Build packages (retry 2)
+        if: steps.build-packages-2.outcome == 'failure'
         run: pnpm --color=always --stream build:production
 
       - name: Check types

--- a/.github/workflows/claude-task.yaml
+++ b/.github/workflows/claude-task.yaml
@@ -1,0 +1,185 @@
+# Claude Code – on-demand task via workflow_dispatch
+# Location: .github/workflows/claude-task.yaml (default branch)
+# Requires:
+#   - GitHub App "Claude" installed on the repo (https://github.com/apps/claude)
+#   - Secret CLAUDE_CODE_OAUTH_TOKEN (org-level, generated with `claude setup-token`)
+# Only users with write+ permission on the repo can trigger it (checked by GitHub).
+#
+# Claude pushes commits via its own GitHub App token (independent of workflow
+# permissions). It is constrained by its system prompt to only push to branches
+# it creates. For defense in depth, enable branch protection rules on the main
+# branch (require PR + approvals).
+
+name: Claude Task
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: Task for Claude
+        required: true
+        type: string
+      model:
+        description: Anthropic model to run
+        required: true
+        type: choice
+        default: claude-opus-4-8
+        options:
+          - claude-opus-4-8
+          - claude-sonnet-4-6
+          - claude-haiku-4-5-20251001
+      runs-on:
+        description: Runner to use
+        required: true
+        type: choice
+        default: ubuntu-24.04-arm
+        options:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-15
+          - macos-15-intel
+      create-pr:
+        description: Create a PR with changes (on a new branch)
+        type: boolean
+        default: false
+
+jobs:
+  claude:
+    runs-on: ${{ github.event.inputs.runs-on }}
+    timeout-minutes: 30
+
+    env:
+      DO_NOT_TRACK: "1"
+      TURBOREPO_CACHE: ${{ github.workspace }}/.turbo
+      RUNS_ON: ${{ github.event.inputs.runs-on }}
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Checkout freelensapp/freelens
+        uses: actions/checkout@v7
+        with:
+          repository: freelensapp/freelens
+          ref: main
+          path: tmp/freelens
+
+      - name: Add upstream remote
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          git remote add upstream ${{ github.server_url }}/${{ github.repository }}.git
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: tmp/freelens/.nvmrc
+          package-manager-cache: false
+
+      - name: Setup pnpm
+        working-directory: tmp/freelens
+        run: corepack enable
+
+      - name: Get pnpm cache directory
+        working-directory: tmp/freelens
+        shell: bash
+        run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
+
+      - name: Use pnpm cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.pnpm_cache_dir }}
+          key: ${{ runner.os }}-${{ runner.arch }}-node-${{ hashFiles('tmp/freelens/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-node-
+
+      - name: Use Turborepo cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.TURBOREPO_CACHE }}
+          key: ${{ runner.os }}-${{ runner.arch }}-turborepo-${{ hashFiles('tmp/freelens/package.json', 'tmp/freelens/freelens/package.json', 'tmp/freelens/packages/**/package.json', 'tmp/freelens/pnpm-lock.yaml','tmp/freelens/turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-turborepo-
+
+      - name: Install pnpm dependencies
+        id: install-pnpm
+        working-directory: tmp/freelens
+        run: pnpm install --color=always --prefer-offline --frozen-lockfile
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        working-directory: tmp/freelens
+        run: pnpm install --color=always --prefer-offline --frozen-lockfile
+
+      - name: Prepare prompt
+        id: prompt
+        shell: bash
+        run: |
+          PROMPT=$(echo "$INPUT_PROMPT" | jq -r '.')
+          if [[ "$CREATE_PR" == "true" ]]; then
+            PROMPT="${PROMPT}
+
+          After making changes, create a new branch (prefix claude/) for the
+          changes, commit, push to origin, and open a pull request. Follow the
+          rules in AGENTS.md (no Conventional Commits prefixes, no emoji)."
+          fi
+          echo "text<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$PROMPT" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+        env:
+          INPUT_PROMPT: ${{ toJSON(github.event.inputs.prompt) }}
+          CREATE_PR: ${{ github.event.inputs.create-pr }}
+
+      - name: Parse model
+        id: parse-model
+        shell: bash
+        run: |
+          DEFAULT_MODEL="claude-opus-4-8"
+          TEXT="${PROMPT_INPUT}"
+
+          MODEL_ALIAS=$(echo "$TEXT" \
+            | grep -oP '\[model:[^\]]+\]' \
+            | head -1 \
+            | sed 's/\[model://;s/\]//' || true)
+
+          MODEL_ALIAS="${MODEL_ALIAS:-}"
+          case "$MODEL_ALIAS" in
+            fable|fable-5|claude-fable-5)               MODEL_ID="claude-fable-5" ;;
+            opus|opus-4|opus-4.8|claude-opus-4-8)       MODEL_ID="claude-opus-4-8" ;;
+            sonnet|sonnet-4|sonnet-4.6|claude-sonnet-4-6) MODEL_ID="claude-sonnet-4-6" ;;
+            haiku|haiku-4|haiku-4.5)                    MODEL_ID="claude-haiku-4-5-20251001" ;;
+            "")                                          MODEL_ID="$DEFAULT_MODEL" ;;
+            *)                                           MODEL_ID="$MODEL_ALIAS" ;;
+          esac
+
+          echo "Resolved model: '${MODEL_ALIAS:-<none>}' -> $MODEL_ID"
+          echo "model=$MODEL_ID" >> "$GITHUB_OUTPUT"
+        env:
+          PROMPT_INPUT: ${{ github.event.inputs.prompt || '' }}
+
+      - name: Use the latest AGENTS.md
+        shell: bash
+        run: |
+          git fetch origin main
+          git show origin/main:AGENTS.md > /tmp/AGENTS.md 2>/dev/null || touch /tmp/AGENTS.md
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prompt.outputs.text }}
+          claude_args: |-
+            --model ${{ steps.parse-model.outputs.model }}
+            --fallback-model claude-sonnet-4-6
+            --max-turns 100
+            --allowedTools "Read" "Write" "Edit" "Glob" "Grep" "Task" "WebSearch" "WebFetch" "BashOutput" "KillShell" "Bash(pnpm:*)" "Bash(npx:*)" "Bash(node:*)" "Bash(git:*)" "Bash(gh:*)" "Bash(yq:*)" "Bash(jq:*)" "Bash(grep:*)" "Bash(rg:*)" "Bash(sed:*)" "Bash(awk:*)" "Bash(cut:*)" "Bash(tr:*)" "Bash(sort:*)" "Bash(uniq:*)" "Bash(cat:*)" "Bash(head:*)" "Bash(tail:*)" "Bash(wc:*)" "Bash(find:*)" "Bash(xargs:*)" "Bash(ls:*)" "Bash(tree:*)" "Bash(mkdir:*)" "Bash(touch:*)" "Bash(cp:*)" "Bash(mv:*)" "Bash(rm:*)" "Bash(tee:*)" "Bash(echo:*)"
+            --append-system-prompt-file /tmp/AGENTS.md

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -1,5 +1,5 @@
-# Claude Code – on-demand assistant via @claude
-# Location: .github/workflows/claude.yml (default branch)
+# Claude Code – on-demand assistant via @claude in PRs and issues
+# Location: .github/workflows/claude.yaml (default branch)
 # Requires:
 #   - GitHub App "Claude" installed on the repo (https://github.com/apps/claude)
 #   - Secret CLAUDE_CODE_OAUTH_TOKEN (org-level, generated with `claude setup-token`)
@@ -9,6 +9,17 @@
 # permissions). It is constrained by its system prompt to only push to the PR
 # branch it was invoked on. For defense in depth, enable branch protection
 # rules on the main branch (require PR + approvals).
+#
+# Jobs:
+#   1. parse – always ubuntu-24.04-arm, parses [model:xxx] and [runs-on:xxx] from the trigger text
+#
+#   Linux / macOS path:
+#   2. claude – runs on the parsed runner, checks out code, invokes Claude Code
+#
+#   Windows path (Claude Code action does not support Windows natively):
+#   2. prepare-windows – Claude writes a PowerShell script, uploads as artifact
+#   3. run-windows – executes the script on the selected Windows runner
+#   4. analyze-windows – Claude reads the output and posts a summary comment
 
 name: Claude
 
@@ -21,50 +32,103 @@ on:
     types: [opened]
   pull_request_review:
     types: [submitted]
-  workflow_dispatch:
-    inputs:
-      prompt:
-        description: Task for Claude
-        required: true
-        type: string
-      model:
-        description: Anthropic model to run
-        required: true
-        type: choice
-        default: claude-sonnet-4-6
-        options:
-          - claude-opus-4-8
-          - claude-sonnet-4-6
-          - claude-haiku-4.5
-      create-pr:
-        description: Create a PR with changes (on a new branch)
-        type: boolean
-        default: false
 
 jobs:
-  claude:
+  parse:
     if: |
-      github.event_name == 'workflow_dispatch' ||
       (
-        (
-          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-          (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-          (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-        ) &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-          github.event.comment.author_association ||
-          github.event.review.author_association ||
-          github.event.issue.author_association)
-      )
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runs-on: ubuntu-24.04-arm
-            arch: arm64
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      ) &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+        github.event.comment.author_association ||
+        github.event.review.author_association ||
+        github.event.issue.author_association)
 
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 2
+
+    outputs:
+      model: ${{ steps.parse.outputs.model }}
+      runs-on: ${{ steps.parse.outputs.runs-on }}
+      is-windows: ${{ steps.parse.outputs.is-windows }}
+      text: ${{ steps.parse.outputs.text }}
+
+    permissions:
+      actions: read
+
+    steps:
+      - name: Parse model and runs-on
+        id: parse
+        shell: bash
+        run: |
+          DEFAULT_MODEL="claude-opus-4-8"
+          DEFAULT_RUNS_ON="ubuntu-24.04-arm"
+          TEXT="${COMMENT_BODY}${REVIEW_BODY}${ISSUE_BODY}"
+
+          # --- model ---
+          MODEL_ALIAS=$(echo "$TEXT" \
+            | grep -oP '\[model:[^\]]+\]' \
+            | head -1 \
+            | sed 's/\[model://;s/\]//' || true)
+          MODEL_ALIAS="${MODEL_ALIAS:-}"
+
+          case "$MODEL_ALIAS" in
+            fable|fable-5|claude-fable-5)               MODEL_ID="claude-fable-5" ;;
+            opus|opus-4|opus-4.8|claude-opus-4-8)       MODEL_ID="claude-opus-4-8" ;;
+            sonnet|sonnet-4|sonnet-4.6|claude-sonnet-4-6) MODEL_ID="claude-sonnet-4-6" ;;
+            haiku|haiku-4|haiku-4.5)                    MODEL_ID="claude-haiku-4-5-20251001" ;;
+            "")                                          MODEL_ID="$DEFAULT_MODEL" ;;
+            *)                                           MODEL_ID="$MODEL_ALIAS" ;;
+          esac
+
+          echo "Resolved model: '${MODEL_ALIAS:-<none>}' -> $MODEL_ID"
+          echo "model=$MODEL_ID" >> "$GITHUB_OUTPUT"
+
+          # --- runs-on ---
+          RUNS_ON_ALIAS=$(echo "$TEXT" \
+            | grep -oP '\[runs-on:[^\]]+\]' \
+            | head -1 \
+            | sed 's/\[runs-on://;s/\]//' || true)
+          RUNS_ON_ALIAS="${RUNS_ON_ALIAS:-}"
+
+          case "$RUNS_ON_ALIAS" in
+            ubuntu-24.04|ubuntu|linux|linux-x64)        RUNS_ON="ubuntu-24.04" ;;
+            ubuntu-24.04-arm|ubuntu-arm|linux-arm|linux-arm64) RUNS_ON="ubuntu-24.04-arm" ;;
+            macos-15|macos|macos-arm64)                  RUNS_ON="macos-15" ;;
+            macos-15-intel|macos-intel|macos-x64)        RUNS_ON="macos-15-intel" ;;
+            windows-11-arm|windows-arm|windows-arm64)    RUNS_ON="windows-11-arm" ;;
+            windows-2025|windows|windows-x64)            RUNS_ON="windows-2025" ;;
+            "")                                          RUNS_ON="$DEFAULT_RUNS_ON" ;;
+            *)                                           RUNS_ON="$RUNS_ON_ALIAS" ;;
+          esac
+
+          echo "Resolved runs-on: '${RUNS_ON_ALIAS:-<none>}' -> $RUNS_ON"
+          echo "runs-on=$RUNS_ON" >> "$GITHUB_OUTPUT"
+
+          # --- is-windows ---
+          case "$RUNS_ON" in
+            windows-*) IS_WINDOWS="true" ;;
+            *)         IS_WINDOWS="false" ;;
+          esac
+          echo "is-windows=$IS_WINDOWS" >> "$GITHUB_OUTPUT"
+
+          # --- text (for Windows jobs that need the original prompt) ---
+          echo "text<<TEXT_EOF" >> "$GITHUB_OUTPUT"
+          echo "$TEXT" >> "$GITHUB_OUTPUT"
+          echo "TEXT_EOF" >> "$GITHUB_OUTPUT"
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          REVIEW_BODY: ${{ github.event.review.body || '' }}
+          ISSUE_BODY: ${{ github.event.issue.body || '' }}
+
+  claude:
+    needs: parse
+    if: always() && needs.parse.result == 'success' && needs.parse.outputs.is-windows != 'true'
+
+    runs-on: ${{ needs.parse.outputs.runs-on }}
     timeout-minutes: 30
 
     env:
@@ -81,17 +145,24 @@ jobs:
     steps:
       - name: Checkout (PR — forked code)
         if: github.event_name == 'issue_comment' && github.event.issue.pull_request || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || format('refs/pull/{0}/head', github.event.issue.number) }}
           fetch-depth: 0
 
-      - name: Checkout (default branch — issues, workflow_dispatch)
-        if: github.event_name == 'issues' || github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && !github.event.issue.pull_request)
-        uses: actions/checkout@v6
+      - name: Checkout (default branch — issues)
+        if: github.event_name == 'issues' || (github.event_name == 'issue_comment' && !github.event.issue.pull_request)
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Checkout freelensapp/freelens
+        uses: actions/checkout@v7
+        with:
+          repository: freelensapp/freelens
+          ref: main
+          path: tmp/freelens
 
       - name: Add upstream remote
         if: github.event.pull_request.head.repo.full_name != github.repository
@@ -101,121 +172,172 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version-file: .nvmrc
+          node-version-file: tmp/freelens/.nvmrc
           package-manager-cache: false
 
       - name: Setup pnpm
+        working-directory: tmp/freelens
         run: corepack enable
 
       - name: Get pnpm cache directory
+        working-directory: tmp/freelens
         shell: bash
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
 
       - name: Use pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.pnpm_cache_dir }}
-          key: ${{ matrix.runs-on }}-${{ matrix.arch }}-node-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-node-${{ hashFiles('tmp/freelens/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ matrix.runs-on }}-${{ matrix.arch }}-node-
+            ${{ runner.os }}-${{ runner.arch }}-node-
 
       - name: Use Turborepo cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.TURBOREPO_CACHE }}
-          key: ${{ matrix.runs-on }}-${{ matrix.arch }}-turborepo-${{ hashFiles('package.json', 'freelens/package.json', 'packages/**/package.json', 'pnpm-lock.yaml','turbo.json') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-turborepo-${{ hashFiles('tmp/freelens/package.json', 'tmp/freelens/freelens/package.json', 'tmp/freelens/packages/**/package.json', 'tmp/freelens/pnpm-lock.yaml','tmp/freelens/turbo.json') }}
           restore-keys: |
-            ${{ matrix.runs-on }}-${{ matrix.arch }}-turborepo-
+            ${{ runner.os }}-${{ runner.arch }}-turborepo-
 
       - name: Install pnpm dependencies
         id: install-pnpm
-        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+        working-directory: tmp/freelens
+        run: pnpm install --color=always --prefer-offline --frozen-lockfile
         continue-on-error: true
 
       - name: Install pnpm dependencies (retry)
         if: steps.install-pnpm.outcome == 'failure'
-        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+        working-directory: tmp/freelens
+        run: pnpm install --color=always --prefer-offline --frozen-lockfile
 
-      - name: Prepare prompt (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        id: prompt
+      - name: Use the latest AGENTS.md
         shell: bash
         run: |
-          PROMPT=$(echo "$INPUT_PROMPT" | jq -r '.')
-          if [[ "$CREATE_PR" == "true" ]]; then
-            PROMPT="${PROMPT}
-
-          After making changes, create a new branch (prefix claude/) for the
-          changes, commit, push to origin, and open a pull request. Follow the
-          rules in AGENTS.md (no Conventional Commits prefixes, no emoji)."
-          fi
-          echo "text<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$PROMPT" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-        env:
-          INPUT_PROMPT: ${{ toJSON(github.event.inputs.prompt) }}
-          CREATE_PR: ${{ github.event.inputs.create-pr }}
-
-      - name: Parse model
-        id: parse-model
-        shell: bash
-        run: |
-          DEFAULT_MODEL="claude-sonnet-4-6"
-          if [[ -n "$WORKFLOW_MODEL" ]]; then
-            MODEL_ID="$WORKFLOW_MODEL"
-            echo "Resolved model from workflow input: $MODEL_ID"
-            echo "model=$MODEL_ID" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # For PR/issue events, look in comment/issue body. For workflow_dispatch, use prompt input.
-          TEXT="${COMMENT_BODY}${REVIEW_BODY}${ISSUE_BODY}${PROMPT_INPUT}"
-
-          MODEL_ALIAS=$(echo "$TEXT" \
-            | grep -oP '\[model:[^\]]+\]' \
-            | head -1 \
-            | sed 's/\[model://;s/\]//' || true)
-
-          MODEL_ALIAS="${MODEL_ALIAS:-}"
-          case "$MODEL_ALIAS" in
-            fable|fable-5|claude-fable-5)               MODEL_ID="claude-fable-5" ;;
-            opus|opus-4|opus-4.8|claude-opus-4-8)       MODEL_ID="claude-opus-4-8" ;;
-            sonnet|sonnet-4|sonnet-4.6|claude-sonnet-4-6) MODEL_ID="claude-sonnet-4-6" ;;
-            haiku|haiku-4|haiku-4.5)                    MODEL_ID="claude-haiku-4-5-20251001" ;;
-            "")                                          MODEL_ID="$DEFAULT_MODEL" ;;
-            *)                                           MODEL_ID="$MODEL_ALIAS" ;;
-          esac
-
-          echo "Resolved model: '${MODEL_ALIAS:-<none>}' -> $MODEL_ID"
-          echo "model=$MODEL_ID" >> "$GITHUB_OUTPUT"
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body || '' }}
-          REVIEW_BODY: ${{ github.event.review.body || '' }}
-          ISSUE_BODY: ${{ github.event.issue.body || '' }}
-          PROMPT_INPUT: ${{ github.event.inputs.prompt || '' }}
-          WORKFLOW_MODEL: ${{ github.event.inputs.model || '' }}
+          git fetch origin main
+          git show origin/main:AGENTS.md > /tmp/AGENTS.md 2>/dev/null || touch /tmp/AGENTS.md
 
       - name: Run Claude Code
-        if: github.event_name != 'workflow_dispatch'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |-
-            --model ${{ steps.parse-model.outputs.model }}
-            --fallback-model claude-sonnet-4-6
-            --max-turns 100
+            --model ${{ needs.parse.outputs.model }}
+            --fallback-model claude-opus-4-8
+            --max-turns 200
             --allowedTools "Read" "Write" "Edit" "Glob" "Grep" "Task" "WebSearch" "WebFetch" "BashOutput" "KillShell" "Bash(pnpm:*)" "Bash(npx:*)" "Bash(node:*)" "Bash(git:*)" "Bash(gh:*)" "Bash(yq:*)" "Bash(jq:*)" "Bash(grep:*)" "Bash(rg:*)" "Bash(sed:*)" "Bash(awk:*)" "Bash(cut:*)" "Bash(tr:*)" "Bash(sort:*)" "Bash(uniq:*)" "Bash(cat:*)" "Bash(head:*)" "Bash(tail:*)" "Bash(wc:*)" "Bash(find:*)" "Bash(xargs:*)" "Bash(ls:*)" "Bash(tree:*)" "Bash(mkdir:*)" "Bash(touch:*)" "Bash(cp:*)" "Bash(mv:*)" "Bash(rm:*)" "Bash(tee:*)" "Bash(echo:*)"
-            --append-system-prompt-file AGENTS.md
+            --append-system-prompt-file /tmp/AGENTS.md
 
-      - name: Run Claude Code (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        uses: anthropics/claude-code-action@v1
+  # ── Windows path: Claude writes PS script → execute on Windows → Claude analyzes ──
+
+  prepare-windows:
+    needs: parse
+    if: always() && needs.parse.result == 'success' && needs.parse.outputs.is-windows == 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+
+    steps:
+      - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: ${{ steps.prompt.outputs.text }}
           claude_args: |-
-            --model ${{ steps.parse-model.outputs.model }}
-            --fallback-model claude-sonnet-4-6
-            --max-turns 100
-            --allowedTools "Read" "Write" "Edit" "Glob" "Grep" "Task" "WebSearch" "WebFetch" "BashOutput" "KillShell" "Bash(pnpm:*)" "Bash(npx:*)" "Bash(node:*)" "Bash(git:*)" "Bash(gh:*)" "Bash(yq:*)" "Bash(jq:*)" "Bash(grep:*)" "Bash(rg:*)" "Bash(sed:*)" "Bash(awk:*)" "Bash(cut:*)" "Bash(tr:*)" "Bash(sort:*)" "Bash(uniq:*)" "Bash(cat:*)" "Bash(head:*)" "Bash(tail:*)" "Bash(wc:*)" "Bash(find:*)" "Bash(xargs:*)" "Bash(ls:*)" "Bash(tree:*)" "Bash(mkdir:*)" "Bash(touch:*)" "Bash(cp:*)" "Bash(mv:*)" "Bash(rm:*)" "Bash(tee:*)" "Bash(echo:*)"
-            --append-system-prompt-file AGENTS.md
+            --model ${{ needs.parse.outputs.model }}
+            --fallback-model claude-opus-4-8
+            --max-turns 50
+            --allowedTools "Write"
+          prompt: |-
+            Based on the following request from a GitHub comment, write a PowerShell
+            script named verify.ps1 that accomplishes the task on a Windows runner.
+
+            The script must be self-contained and idempotent.
+            After completing the work, save a JSON summary to result.json with the
+            keys: exitCode (number), stdout (string), stderr (string), summary
+            (string – a human-readable summary of what happened).
+
+            Request:
+
+            ${{ needs.parse.outputs.text }}
+
+      - name: Upload PowerShell script
+        uses: actions/upload-artifact@v7
+        with:
+          name: ps-script
+          path: verify.ps1
+
+  run-windows:
+    needs: [parse, prepare-windows]
+    if: always() && needs.prepare-windows.result == 'success'
+    runs-on: ${{ needs.parse.outputs.runs-on }}
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - name: Download PowerShell script
+        uses: actions/download-artifact@v8
+        with:
+          name: ps-script
+
+      - name: Execute verification
+        shell: pwsh
+        run: ./verify.ps1
+        continue-on-error: true
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: verify-results
+          path: result.json
+
+  analyze-windows:
+    needs: [parse, run-windows]
+    if: always() && needs.run-windows.result != 'skipped'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+      actions: read
+      id-token: write
+
+    steps:
+      - name: Download results from Windows
+        uses: actions/download-artifact@v8
+        with:
+          name: verify-results
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |-
+            --model ${{ needs.parse.outputs.model }}
+            --fallback-model claude-opus-4-8
+            --max-turns 30
+            --allowedTools "Read" "Grep" "Bash(gh:*)" "Bash(jq:*)" "Bash(cat:*)"
+          prompt: |-
+            Read the file result.json (output from a test executed on a Windows
+            runner). Write a short summary as a GitHub comment on the PR or issue
+            that triggered this workflow. Include: whether it succeeded, the exit
+            code, and any suspicious output in stdout/stderr.
+
+            Use the GitHub CLI (gh) to post the comment. The trigger event is
+            ${{ github.event_name }}.
+
+            If the event is issue_comment, the comment URL is:
+            ${{ github.event.comment.html_url }}
+            If the event is pull_request_review_comment, the comment URL is:
+            ${{ github.event.comment.html_url }}
+            If the event is issues, the issue URL is:
+            ${{ github.event.issue.html_url }}
+            If the event is pull_request_review, the review URL is:
+            ${{ github.event.review.html_url }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -24,8 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - freelens_version: v1.10.0
-          - freelens_version: main
+          - freelens_version: v1.10.0
 
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
@@ -40,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout plugin
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup node
         uses: actions/setup-node@v6
@@ -55,7 +54,7 @@ jobs:
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
 
       - name: Use pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.pnpm_cache_dir }}
           key: node-freelens-${{ matrix.freelens_version }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -72,6 +71,18 @@ jobs:
         run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
 
       - name: Build plugin
+        id: build-plugin
+        run: pnpm build
+        continue-on-error: true
+
+      - name: Build plugin (retry)
+        id: build-plugin-2
+        if: steps.build-plugin.outcome == 'failure'
+        run: pnpm build
+        continue-on-error: true
+
+      - name: Build plugin (retry 2)
+        if: steps.build-plugin-2.outcome == 'failure'
         run: pnpm build
 
       - name: Pack plugin
@@ -82,7 +93,7 @@ jobs:
 
       - name: Checkout app
         if: matrix.freelens_version != 'latest'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: freelensapp/freelens
           ref: ${{ matrix.freelens_version }}
@@ -104,7 +115,7 @@ jobs:
         run: echo "playwright_version=$(yq -r .importers.freelens.devDependencies.playwright.version freelens/pnpm-lock.yaml | sed 's/(.*)//')" >> $GITHUB_ENV
 
       - name: Use Electron cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.ELECTRON_CACHE }}
           key: ubuntu-24.04-arm-electron-${{ env.electron_version }}
@@ -112,7 +123,7 @@ jobs:
             ubuntu-24.04-arm-electron-
 
       - name: Use Electron Builder cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.ELECTRON_BUILDER_CACHE }}
           key: ubuntu-24.04-arm-electron-builder-${{ env.electron_builder_version }}
@@ -121,14 +132,14 @@ jobs:
 
       - name: Use Electron headers cache
         id: electron-headers
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.ELECTRON_HEADERS_CACHE }}
           key: electron-headers-${{ env.electron_version }}
 
       - name: Use Playwright cache
         id: playwright-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: ubuntu-24.04-arm-playwright-${{ env.playwright_version }}
@@ -136,12 +147,28 @@ jobs:
             ubuntu-24.04-arm-playwright-
 
       - name: Use Turborepo cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.TURBOREPO_CACHE }}
           key: ubuntu-24.04-arm-turborepo-${{ hashFiles('freelens/**/package.json', 'freelens/**/pnpm-lock.yaml', 'freelens/turbo.json') }}
           restore-keys: |
             ubuntu-24.04-arm-turborepo-
+
+      # The packaged Electron app does not depend on the extension under test
+      # (the extension .tgz is installed at runtime by the integration tests),
+      # so the build output is deterministic for a given Freelens version and
+      # Electron/electron-builder version. Restore it to skip the expensive app
+      # build, native rebuild, prod node_modules deploy and electron-builder run
+      # on a cache hit. The cache key is exact (no restore-keys) so a partial
+      # match never produces a stale or incomplete dist directory. The matching
+      # save step runs only after a successful build, so a failed build never
+      # poisons the cache with an incomplete dist.
+      - name: Restore Electron build cache
+        id: electron-build-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: freelens/freelens/dist
+          key: ubuntu-24.04-arm-electron-dist-${{ matrix.freelens_version }}-${{ env.electron_version }}-${{ env.electron_builder_version }}
 
       - name: Delete node packages from the previous build to avoid issues with pnpm
         run: rm -rf pnpm-lock.yaml node_modules
@@ -165,7 +192,7 @@ jobs:
         run: pnpm config set enablePrePostScripts false
 
       - name: Install Electron headers
-        if: steps.electron-headers.outputs.cache-hit != 'true'
+        if: steps.electron-build-cache.outputs.cache-hit != 'true' && steps.electron-headers.outputs.cache-hit != 'true'
         run: |
           set -eo pipefail
           mkdir -p $ELECTRON_HEADERS_CACHE
@@ -174,14 +201,15 @@ jobs:
       - name: Install Playwright with dependencies
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: freelens
-        run: pnpx playwright install --with-deps
+        run: pnpx playwright install --with-deps chromium
 
       - name: Install Playwright's dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         working-directory: freelens
-        run: pnpx playwright install-deps
+        run: pnpx playwright install-deps chromium
 
       - name: Build app
+        if: steps.electron-build-cache.outputs.cache-hit != 'true'
         working-directory: freelens
         run: pnpm --color=always --stream build
 
@@ -201,35 +229,39 @@ jobs:
 
       - name: Build extra resources
         id: build-resources
+        if: steps.electron-build-cache.outputs.cache-hit != 'true'
         working-directory: freelens
         run: pnpm --color=always build:resources
         continue-on-error: true
 
       - name: Build extra resources (retry)
         id: build-resources-2
-        if: steps.build-resources.outcome == 'failure'
+        if: steps.electron-build-cache.outputs.cache-hit != 'true' && steps.build-resources.outcome == 'failure'
         working-directory: freelens
         run: pnpm --color=always build:resources
         continue-on-error: true
 
       - name: Build extra resources (retry 2)
-        if: steps.build-resources-2.outcome == 'failure'
+        if: steps.electron-build-cache.outputs.cache-hit != 'true' && steps.build-resources-2.outcome == 'failure'
         working-directory: freelens
         run: pnpm --color=always build:resources
 
       - name: Rebuild native packages for Electron
+        if: steps.electron-build-cache.outputs.cache-hit != 'true'
         working-directory: freelens
         run: pnpm --color=always electron-rebuild -a arm64
         env:
           npm_package_config_node_gyp_tarball: ${{ env.ELECTRON_HEADERS_CACHE }}/node-v${{ env.electron_version }}-headers.tar.gz
 
       - name: Get electron-builder path
+        if: steps.electron-build-cache.outputs.cache-hit != 'true'
         working-directory: freelens/freelens
         run: |
           EB_PATH=$(node -e "console.log(require.resolve('electron-builder/cli'))")
           echo "ELECTRON_BUILDER_PATH=$EB_PATH" >> $GITHUB_ENV
 
       - name: Deploy production node_modules
+        if: steps.electron-build-cache.outputs.cache-hit != 'true'
         working-directory: freelens
         run: |
           pnpm deploy --legacy --prod --filter=freelens freelens/node_modules_prod
@@ -237,16 +269,28 @@ jobs:
           mv freelens/node_modules_prod freelens/node_modules
 
       - name: Build Electron app
+        if: steps.electron-build-cache.outputs.cache-hit != 'true'
         working-directory: freelens/freelens
         run: node "$ELECTRON_BUILDER_PATH" --publish never --linux dir --arm64
         env:
           DEBUG: electron-builder,electron-builder:*
           npm_config_user_agent: pnpm
 
+      # Save only after a successful build (this step is not reached if the
+      # electron-builder run above failed), so the cache never holds a partial
+      # dist directory.
+      - name: Save Electron build cache
+        if: steps.electron-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: freelens/freelens/dist
+          key: ${{ steps.electron-build-cache.outputs.cache-primary-key }}
+
       - name: Restore dev node_modules
+        if: steps.electron-build-cache.outputs.cache-hit != 'true'
         working-directory: freelens
         run: |
-          mv freelens/node_modules freelens/node_modules_prod
+          rm -rf freelens/node_modules
           mv freelens/node_modules_dev freelens/node_modules
 
       - name: Run integration tests

--- a/.github/workflows/npm-audit.yaml
+++ b/.github/workflows/npm-audit.yaml
@@ -24,7 +24,7 @@ jobs:
     if: github.event_name != 'issue_comment' || (startsWith(github.event.issue.title, 'Automated npm audit') && contains(github.event.comment.body, '/rerun'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
 
       - name: Use pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.pnpm_cache_dir }}
           key: ubuntu-24.04-arm-node-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/npm-dedupe.yaml
+++ b/.github/workflows/npm-dedupe.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
 
       - name: Use pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.pnpm_cache_dir }}
           key: ubuntu-24.04-arm-node-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/npm-version.yaml
+++ b/.github/workflows/npm-version.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GH_TOKEN }}
 
@@ -43,7 +43,7 @@ jobs:
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
 
       - name: Use pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.pnpm_cache_dir }}
           key: ubuntu-24.04-arm-node-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout plugin
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Check if package version matches
         run: test "${GITHUB_REF_NAME}" = "v$(yq -r .version package.json)"
@@ -44,7 +44,7 @@ jobs:
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
 
       - name: Use pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.pnpm_cache_dir }}
           key: ubuntu-24.04-arm-node-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -61,6 +61,18 @@ jobs:
         run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
 
       - name: Build packages
+        id: build-packages
+        run: pnpm --color=always --stream build
+        continue-on-error: true
+
+      - name: Build packages (retry)
+        id: build-packages-2
+        if: steps.build-packages.outcome == 'failure'
+        run: pnpm --color=always --stream build
+        continue-on-error: true
+
+      - name: Build packages (retry 2)
+        if: steps.build-packages-2.outcome == 'failure'
         run: pnpm --color=always --stream build
 
       - name: Pack packages
@@ -125,9 +137,35 @@ jobs:
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          upload-release-assets: false
+
+      - name: Normalize SBOM filename
+        shell: bash
+        run: |
+          for f in *.tgz; do
+            mv sbom.spdx.json "${f%.tgz}-spdx.json"
+          done
+
+      - name: Make checksums
+        shell: bash
+        run: |
+          for f in *.tgz *-spdx.json; do
+            sha256sum "$f" | tee "$f.sha256"
+          done
+
       - name: Create release
         uses: softprops/action-gh-release@v3
         with:
           fail_on_unmatched_files: true
           files: |-
             *.tgz
+            *.tgz.sha256
+            *-spdx.json
+            *-spdx.json.sha256

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -26,7 +26,7 @@ jobs:
     if: (startsWith(github.event.issue.title, 'Automated npm version') && github.event.issue.state == 'closed' && github.event.comment.body == '/tag') || (startsWith(github.event.pull_request.title, 'Automated npm version') && github.event.pull_request.merged)
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main

--- a/.github/workflows/trunk-check.yaml
+++ b/.github/workflows/trunk-check.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -28,7 +28,7 @@ jobs:
     if: github.event_name != 'issue_comment' || (startsWith(github.event.issue.title, 'Automated trunk upgrade') && contains(github.event.comment.body, '/rerun'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GH_TOKEN }}
 
@@ -46,7 +46,7 @@ jobs:
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
 
       - name: Use pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.pnpm_cache_dir }}
           key: ubuntu-24.04-arm-node-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup node
         uses: actions/setup-node@v6
@@ -37,7 +37,7 @@ jobs:
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
 
       - name: Use pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.pnpm_cache_dir }}
           key: ubuntu-24.04-arm-node-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/build/global-externals.js
+++ b/build/global-externals.js
@@ -1,0 +1,175 @@
+// Vite/Rolldown plugin that maps bare module ids (react, mobx, ...) to runtime
+// globals provided by the Freelens host (global.React, global.Mobx, ...).
+//
+// This replaces `vite-plugin-external`, whose CommonJS shim
+// (`module.exports = global.React`) only exposes a statically detectable
+// `default` export. Rolldown discovers the *named* exports of such a CJS shim
+// through a non-deterministic static-analysis / dep pre-bundle step, so builds
+// intermittently failed with errors such as:
+//
+//   [MISSING_EXPORT] "forwardRef" is not exported by ".vite_external/react.js"
+//
+// when a third-party dependency (lucide-react, react-syntax-highlighter, ...)
+// did `import { forwardRef } from "react"` and the detection lost the race.
+//
+// Instead, this plugin emits an ESM shim with *explicit* named exports, so the
+// module graph is fully static and the build is deterministic:
+//
+//   const __m = global.React;
+//   export default __m;
+//   export const forwardRef = __m.forwardRef;
+//   ...
+//
+// (Rolldown 1.0.3 does not support `syntheticNamedExports`, so the names must
+// be materialized explicitly.) The export names are discovered at config time
+// from the installed package, with no hardcoded lists.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// electron-vite bundles this config helper before running it, so __dirname is
+// unreliable. Builds always run from the project root, so use the cwd.
+const ROOT = process.cwd();
+
+const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+// Names that are valid object keys but cannot be used as `export const <name>`.
+const RESERVED = new Set([
+  "default",
+  "__esModule",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "new",
+  "null",
+  "return",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+]);
+
+function packageNameOf(id) {
+  const parts = id.split("/");
+  return id.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
+}
+
+// Resolve the on-disk entry of a module, falling back to the pnpm virtual store
+// for host-only peer dependencies (react-dom, react-router-dom) that are not
+// hoisted to the project root.
+function resolveEntry(id) {
+  try {
+    return require.resolve(id, { paths: [ROOT] });
+  } catch {}
+  const pnpmDir = path.join(ROOT, "node_modules", ".pnpm");
+  let entries = [];
+  try {
+    entries = fs.readdirSync(pnpmDir);
+  } catch {
+    return null;
+  }
+  const prefix = `${packageNameOf(id).replace(/\//g, "+")}@`;
+  for (const dir of entries.filter((e) => e.startsWith(prefix)).sort()) {
+    const base = path.join(pnpmDir, dir, "node_modules", packageNameOf(id));
+    try {
+      return require.resolve(id, { paths: [path.dirname(base)] });
+    } catch {}
+  }
+  return null;
+}
+
+// Extract export names from a CJS/webpack bundle without executing it. Some host
+// packages (e.g. @freelensapp/extensions) run browser-only code on require and
+// cannot be loaded in Node at build time.
+function namesFromSource(src) {
+  const found = new Set();
+  // webpack harmony exports: __webpack_require__.d(exports, { Name: () => ... })
+  for (const block of src.matchAll(/__webpack_require__\.d\(\s*\w+\s*,\s*\{([\s\S]*?)\}\s*\)/g)) {
+    for (const m of block[1].matchAll(/([A-Za-z_$][A-Za-z0-9_$]*)\s*:/g)) found.add(m[1]);
+  }
+  // plain CJS: exports.Name = ... / Object.defineProperty(exports, "Name", ...)
+  for (const m of src.matchAll(/exports\.([A-Za-z_$][A-Za-z0-9_$]*)\s*=/g)) found.add(m[1]);
+  for (const m of src.matchAll(/Object\.defineProperty\(\s*exports\s*,\s*["']([A-Za-z_$][A-Za-z0-9_$]*)["']/g))
+    found.add(m[1]);
+  return [...found];
+}
+
+function resolveExportNames(id) {
+  const entry = resolveEntry(id);
+  // Preferred: require the real module and read its keys.
+  try {
+    const real = require(entry || id);
+    const keys = Object.keys(real).filter((n) => IDENTIFIER_RE.test(n) && !RESERVED.has(n));
+    if (keys.length > 0) return keys;
+  } catch {}
+  // Fallback: static parse for modules that cannot be required in Node.
+  if (entry) {
+    try {
+      return namesFromSource(fs.readFileSync(entry, "utf8")).filter((n) => IDENTIFIER_RE.test(n) && !RESERVED.has(n));
+    } catch {}
+  }
+  return [];
+}
+
+/**
+ * @param {Record<string, string>} globals map of module id -> global expression
+ *   (e.g. { react: "global.React" }).
+ */
+function globalExternals(globals) {
+  const PREFIX = "\0global-external:";
+  const codeCache = new Map();
+  return {
+    name: "global-externals",
+    enforce: "pre",
+    resolveId(id) {
+      if (Object.prototype.hasOwnProperty.call(globals, id)) {
+        return { id: PREFIX + id, moduleSideEffects: false };
+      }
+      return null;
+    },
+    load(id) {
+      if (!id.startsWith(PREFIX)) return null;
+      const moduleId = id.slice(PREFIX.length);
+      let code = codeCache.get(moduleId);
+      if (code == null) {
+        const globalName = globals[moduleId];
+        const names = resolveExportNames(moduleId);
+        code = [
+          `const __m = ${globalName};`,
+          `export default __m;`,
+          ...names.map((name) => `export const ${name} = __m.${name};`),
+        ].join("\n");
+        codeCache.set(moduleId, code);
+      }
+      return { code, moduleSideEffects: false };
+    },
+  };
+}
+
+module.exports = { globalExternals };

--- a/electron.vite.config.js
+++ b/electron.vite.config.js
@@ -1,8 +1,15 @@
+import { builtinModules } from "node:module";
 import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
-import { defineConfig, externalizeDepsPlugin } from "electron-vite";
-import pluginExternal from "vite-plugin-external";
+import { defineConfig } from "electron-vite";
 import sassDts from "vite-plugin-sass-dts";
+import { globalExternals } from "./build/global-externals.js";
+
+// Modules provided by the Node.js/Electron runtime in the Freelens host. They
+// must stay external (left as `require(...)`) instead of being bundled. We list
+// them explicitly because setting `rolldownOptions` opts out of the
+// `rollupOptions.external` that electron-vite would otherwise apply.
+const runtimeExternals = ["electron", /^electron\//, ...builtinModules, ...builtinModules.map((m) => `node:${m}`)];
 
 export default defineConfig({
   // main process has full access to Node.js APIs
@@ -14,6 +21,7 @@ export default defineConfig({
         formats: ["cjs"],
       },
       rolldownOptions: {
+        external: runtimeExternals,
         output: {
           // silence warning about using `chunk.default` to access the default export
           exports: "named",
@@ -43,16 +51,10 @@ export default defineConfig({
           ],
         },
       }),
-      externalizeDepsPlugin({
-        // do not bundle modules provided by the host app
-        include: ["@freelensapp/extensions", "mobx"],
-      }),
-      pluginExternal({
+      globalExternals({
         // the modules are provided by the host app as a global variable
-        externals: {
-          "@freelensapp/extensions": "global.LensExtensions",
-          mobx: "global.Mobx",
-        },
+        "@freelensapp/extensions": "global.LensExtensions",
+        mobx: "global.Mobx",
       }),
     ],
   },
@@ -67,6 +69,7 @@ export default defineConfig({
       },
       outDir: "out/renderer",
       rolldownOptions: {
+        external: runtimeExternals,
         output: {
           // silence warning about using `chunk.default` to access the default export
           exports: "named",
@@ -104,31 +107,15 @@ export default defineConfig({
           ],
         },
       }),
-      externalizeDepsPlugin({
-        // do not bundle modules provided by the host app
-        include: [
-          "@freelensapp/extensions",
-          "electron",
-          "mobx",
-          "mobx-react",
-          "react",
-          "react-dom",
-          "react-router-dom",
-        ],
-        // bundle all other modules
-        exclude: [],
-      }),
-      pluginExternal({
+      globalExternals({
         // the modules are provided by the host app as a global variable
-        externals: {
-          "@freelensapp/extensions": "global.LensExtensions",
-          mobx: "global.Mobx",
-          "mobx-react": "global.MobxReact",
-          react: "global.React",
-          "react-dom": "global.ReactDom",
-          "react-router-dom": "global.ReactRouterDom",
-          "react/jsx-runtime": "global.ReactJsxRuntime",
-        },
+        "@freelensapp/extensions": "global.LensExtensions",
+        mobx: "global.Mobx",
+        "mobx-react": "global.MobxReact",
+        react: "global.React",
+        "react-dom": "global.ReactDom",
+        "react-router-dom": "global.ReactRouterDom",
+        "react/jsx-runtime": "global.ReactJsxRuntime",
       }),
     ],
   },

--- a/integration/__tests__/extensions.tests.ts
+++ b/integration/__tests__/extensions.tests.ts
@@ -102,11 +102,20 @@ describe("extensions page tests", () => {
       await window.waitForSelector('div[class*="installed-extensions-module__enabled--"]')
     ).textContent();
     expect(installedExtensionState).toBe("Enabled");
-    console.log('await window.click i[data-testid*="close-notification-for-notification_"]');
-    await window.click('i[data-testid*="close-notification-for-notification_"]');
-    console.log('await window.click div[class*=[close-button-module__closeButton--"][aria-label="Close"]');
-    await window.click('div[class*="close-button-module__closeButton--"][aria-label="Close"]');
-  }, 15 * 1000);
+    // Dismiss any notifications so a notification still in its enter animation
+    // does not intercept pointer events on the elements behind it.
+    console.log("dismiss notifications");
+    const notificationCloseSelector =
+      'i[data-testid*="close-notification-for-notification_"], div[class*="close-button-module__closeButton--"][aria-label="Close"]';
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const closeButtons = await window.$$(notificationCloseSelector);
+      if (closeButtons.length === 0) break;
+      for (const closeButton of closeButtons) {
+        await closeButton.click({ force: true }).catch(() => {});
+      }
+      await window.waitForTimeout(200);
+    }
+  }, 120 * 1000);
 
   afterAll(
     async () => {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "typescript": "5.9.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.8",
-    "vite-plugin-external": "^6.2.2",
     "vite-plugin-sass-dts": "^1.3.37"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@24.12.4)(esbuild@0.27.2)(jiti@2.4.2)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.99.0)(stylus@0.62.0)(terser@5.39.0)
-      vite-plugin-external:
-        specifier: ^6.2.2
-        version: 6.2.2
       vite-plugin-sass-dts:
         specifier: ^1.3.37
         version: 1.3.37(postcss@8.5.15)(prettier@3.6.2)(sass-embedded@1.89.2)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.2)(jiti@2.4.2)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.99.0)(stylus@0.62.0)(terser@5.39.0))
@@ -1177,17 +1174,11 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/debug@4.1.12':
-    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
-
-  '@types/fs-extra@11.0.4':
-    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
 
   '@types/history@4.7.11':
     resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
@@ -1198,14 +1189,8 @@ packages:
   '@types/http-cache-semantics@4.0.4':
     resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
 
-  '@types/jsonfile@6.1.4':
-    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
-
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
-
-  '@types/ms@2.1.0':
-    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
@@ -1392,15 +1377,6 @@ packages:
       bare-events:
         optional: true
 
-  base-log-factory@2.1.4:
-    resolution: {integrity: sha512-FK1tHOB+rXvlBcGYYhSNR2QS2juEG4SZ1ekXQRQ2XscYNtDxllzqkzfgBFr12EVrKb2/07NLdbr0cSwVoc378A==}
-
-  blf-colorful-appender@1.0.6:
-    resolution: {integrity: sha512-MdwOI17J8iOC2XKi5b4VagAJg308R4QesRoCAPw/w7ihzwkTst91LvkTAF3GvPJCEaHXptiUS2UsFkCNiBIEGg==}
-
-  blf-debug-appender@1.0.5:
-    resolution: {integrity: sha512-ftNcGiVW2nxzG0WJ8Hcs58CbygPl2vMuLDDSxsfhGZmVl2NFGmZOuXhDDeJifvWmP0FHzP/L8dblxn65eQjgEA==}
-
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -1570,9 +1546,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  date-manip@2.0.6:
-    resolution: {integrity: sha512-QGLawF3lq5NOqJ5+pIgvrmE1jL8W9iwwHPAdKyV6gydtmDPngty+87YpSpzMPk9lAMnBIXcf57OKSDEjfuyRyw==}
 
   debounce-fn@4.0.0:
     resolution: {integrity: sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==}
@@ -1794,11 +1767,6 @@ packages:
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
 
-  figlet@1.8.2:
-    resolution: {integrity: sha512-iPCpE9B/rOcjewIzDnagP9F2eySzGeHReX8WlrZQJkqFBk2wvq8gY0c6U6Hd2y9HnX1LQcYSeP7aEHoPt6sVKQ==}
-    engines: {node: '>= 0.4.0'}
-    hasBin: true
-
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -2012,9 +1980,6 @@ packages:
 
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
-
-  is-what-type@1.1.4:
-    resolution: {integrity: sha512-120PeT8LdXO7m503rQtOapWA7lHBtWErN+asRxKyxF/SFGeqLEAZhlItjNynNVABHteRMSjomQCdAnxEJldMMQ==}
 
   is-what@3.14.1:
     resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
@@ -3120,10 +3085,6 @@ packages:
   varint@6.0.0:
     resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
 
-  vite-plugin-external@6.2.2:
-    resolution: {integrity: sha512-OpdFlWgVfWyZgx9nym3LAQp4DciutbqwSKzbA1l2Bg7CNzlDd3jnHfv1uWTY4y5h2gRfgT60ZtOgF5+W95i+3A==}
-    engines: {node: '>=14.18.0', vite: '>=3.1.0'}
-
   vite-plugin-sass-dts@1.3.37:
     resolution: {integrity: sha512-R3TgyrMhHh81sBuFFt5FjEWRbFeukoqwIeUmQDxJKYhOk8lafkftvoSqKsfWMepXQL73cu3HFk6FD6nLZ2mDjA==}
     engines: {node: '>=20'}
@@ -3216,10 +3177,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  vp-runtime-helper@1.0.10:
-    resolution: {integrity: sha512-2HUCkqI0uwgBti1/+utRu7Hvk/I3HeowBQfRlEL3487r+LpW1w91kk6uTZbwOd6I2Sj3aAxBE0HxYNC/NLbuhA==}
-    engines: {node: '>=14.18.0', vite: '>=3.1.0'}
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -4633,18 +4590,9 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/debug@4.1.12':
-    dependencies:
-      '@types/ms': 2.1.0
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
-
-  '@types/fs-extra@11.0.4':
-    dependencies:
-      '@types/jsonfile': 6.1.4
-      '@types/node': 24.12.4
 
   '@types/history@4.7.11': {}
 
@@ -4655,15 +4603,9 @@ snapshots:
 
   '@types/http-cache-semantics@4.0.4': {}
 
-  '@types/jsonfile@6.1.4':
-    dependencies:
-      '@types/node': 24.12.4
-
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 24.12.4
-
-  '@types/ms@2.1.0': {}
 
   '@types/node@22.19.17':
     dependencies:
@@ -4838,26 +4780,6 @@ snapshots:
       bare-events: 2.6.0
     optional: true
 
-  base-log-factory@2.1.4:
-    dependencies:
-      date-manip: 2.0.6
-      is-what-type: 1.1.4
-
-  blf-colorful-appender@1.0.6:
-    dependencies:
-      base-log-factory: 2.1.4
-      picocolors: 1.1.1
-
-  blf-debug-appender@1.0.5:
-    dependencies:
-      '@types/debug': 4.1.12
-      base-log-factory: 2.1.4
-      blf-colorful-appender: 1.0.6
-      date-manip: 2.0.6
-      debug: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
-
   boolean@3.2.0:
     optional: true
 
@@ -5028,8 +4950,6 @@ snapshots:
       tiny-invariant: 1.3.3
 
   csstype@3.2.3: {}
-
-  date-manip@2.0.6: {}
 
   debounce-fn@4.0.0:
     dependencies:
@@ -5290,8 +5210,6 @@ snapshots:
 
   fecha@4.2.3: {}
 
-  figlet@1.8.2: {}
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -5506,8 +5424,6 @@ snapshots:
   is-stream@2.0.1: {}
 
   is-url@1.2.4: {}
-
-  is-what-type@1.1.4: {}
 
   is-what@3.14.1:
     optional: true
@@ -6553,15 +6469,6 @@ snapshots:
 
   varint@6.0.0: {}
 
-  vite-plugin-external@6.2.2:
-    dependencies:
-      '@types/fs-extra': 11.0.4
-      fs-extra: 11.3.5
-      is-what-type: 1.1.4
-      vp-runtime-helper: 1.0.10
-    transitivePeerDependencies:
-      - supports-color
-
   vite-plugin-sass-dts@1.3.37(postcss@8.5.15)(prettier@3.6.2)(sass-embedded@1.89.2)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.2)(jiti@2.4.2)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.99.0)(stylus@0.62.0)(terser@5.39.0)):
     dependencies:
       postcss: 8.5.15
@@ -6614,17 +6521,6 @@ snapshots:
       '@types/node': 24.12.4
     transitivePeerDependencies:
       - msw
-
-  vp-runtime-helper@1.0.10:
-    dependencies:
-      '@types/fs-extra': 11.0.4
-      base-log-factory: 2.1.4
-      blf-debug-appender: 1.0.5
-      figlet: 1.8.2
-      fs-extra: 11.3.5
-      picocolors: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
 
   why-is-node-running@2.3.0:
     dependencies:


### PR DESCRIPTION
Ports freelensapp/freelens-example-extension#5275 to this project.

Replaces `vite-plugin-external` with an inline `globalExternals` plugin (`build/global-externals.js`) that emits ESM shims with explicit, statically-known named exports pointing to the runtime globals the Freelens host provides.

Closes #46