### PR TITLE
Sync Claude setup with freelens-example-extension

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"\nimport json, sys, re\ninput_data = json.load(sys.stdin)\ntool = input_data.get('tool_name', '')\nparams = input_data.get('tool_input', {})\npath = params.get('file_path', '')\npatterns = [\n    r'(^|/)\\.env$',\n    r'(^|/)\\.env\\.',\n    r'\\.npmrc$',\n    r'\\.pem$',\n    r'\\.key$',\n    r'serviceAccountKey\\.json$',\n    r'credentials\\.json$'\n]\nif any(re.search(p, path) for p in patterns):\n    print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'deny', 'permissionDecisionReason': 'Sensitive file excluded for security: ' + path}}))\n    sys.exit(0)\nprint(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow'}}))\n\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,12 +20,12 @@ Freelens extension for Kubernetes Gateway API CRDs (v1, v1alpha2, v1beta1). Prov
 pnpm type:check
 
 # Linting & formatting
-pnpm biome:check          # TypeScript/TSX (biome) — prefer this for TS/TSX
-pnpm biome:fix            # Auto-fix TypeScript/TSX
-pnpm trunk:check          # SCSS, Markdown, and other formats not covered by biome
-pnpm trunk:fix            # Auto-fix SCSS, Markdown, etc.
-pnpm lint:check           # biome + prettier check (all formats)
-pnpm lint:fix             # biome + prettier fix (all formats)
+pnpm biome:check          # TypeScript/TSX, JS, JSON, CSS/SCSS, HTML (biome)
+pnpm biome:fix            # Auto-fix the formats above
+pnpm trunk:check          # Markdown, YAML, TOML, and other formats not covered by biome
+pnpm trunk:fix            # Auto-fix Markdown, YAML, etc.
+pnpm lint:check           # Alias for biome:check
+pnpm lint:fix             # Alias for biome:fix
 
 # Tests
 pnpm test:unit            # vitest
@@ -118,8 +118,8 @@ Other dependencies ARE bundled into the extension output.
 
 ## Code Style
 
-- **Biome** formats **TypeScript/TSX**: double quotes, semicolons, trailing commas, 2-space indent, 120 char line width
-- **Trunk** formats **SCSS, Markdown**, and other non-TS formats — use `pnpm trunk:fix`
+- **Biome** formats **TypeScript/TSX, JS, JSON, CSS/SCSS, HTML**: double quotes, semicolons, trailing commas, 2-space indent, 120 char line width — use `pnpm biome:fix`
+- **Trunk** formats **Markdown, YAML**, and other formats not covered by biome — use `pnpm trunk:fix`
 - Import order (enforced by biome organizeImports): built-in modules → `@freelensapp/**` → packages → relative paths
 - React 17 (no `react/jsx-runtime` in tsconfig needed, but handled by build)
 - **No emoji** in Markdown files (`.md`), comments, or any source code
@@ -176,8 +176,8 @@ Code in `src/common/` is shared between both processes.
 2. **Follow existing patterns** — grep for similar implementations before creating new ones
 3. **Test changes** before committing
 4. **Run validation before committing:** `pnpm lint:fix && pnpm type:check && pnpm test:unit`
-5. **For TypeScript/TSX files:** run `pnpm biome:fix` (or `biome check` directly if `biome` is installed locally)
-6. **For SCSS, Markdown, and other formats:** run `pnpm trunk:fix` (or `trunk check` directly if `trunk` is installed locally)
+5. **For TypeScript/TSX, JS, JSON, CSS/SCSS, HTML files:** run `pnpm biome:fix` (or `biome check` directly if `biome` is installed locally)
+6. **For Markdown, YAML, and other formats:** run `pnpm trunk:fix` (or `trunk check` directly if `trunk` is installed locally)
 7. **Full build** when in doubt about cached state: `pnpm clean:all && pnpm build`
 8. **Do not use Anthropic Fable for coding tasks** — Fable may be used only for planning,
    analysis, and thinking through problems. When writing or editing code,


### PR DESCRIPTION
Syncs Claude-related files with freelensapp/freelens-example-extension.

Changes:
- Update AGENTS.md linting/formatting descriptions to reflect full Biome and Trunk coverage
- Add .claude/settings.json with PreToolUse security hooks blocking sensitive file reads

Closes #47