### PR TITLE
Group all @freelensapp/* dependency updates into one Renovate PR

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -35,6 +35,13 @@
     "react-router-dom",
   ],
   "packageRules": [
+    // group all @freelensapp/* updates into one PR
+    {
+      "matchPackageNames": [
+        "@freelensapp/**"
+      ],
+      "groupName": "freelensapp"
+    },
     // peerDependencies are widen
     {
       "matchDepTypes": [


### PR DESCRIPTION
Adds a Renovate package rule that groups all `@freelensapp/*` dependency updates into a single PR.

Resolves #55
