### PR TITLE
Add unit tests for Gateway API helpers

### DIFF
--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { maybe } from "./utils";
+
+describe("maybe", () => {
+  test("returns the value when the callback succeeds", () => {
+    expect(maybe(() => 42)).toBe(42);
+  });
+
+  test("returns null when the callback throws", () => {
+    expect(
+      maybe(() => {
+        throw new Error("boom");
+      }),
+    ).toBeNull();
+  });
+
+  test("preserves falsy non-throwing values", () => {
+    expect(maybe(() => 0)).toBe(0);
+    expect(maybe(() => "")).toBe("");
+    expect(maybe(() => false)).toBe(false);
+  });
+
+  test("returns the resolved object reference unchanged", () => {
+    const value = { a: 1 };
+    expect(maybe(() => value)).toBe(value);
+  });
+});

--- a/src/renderer/api/k8s/statuses.test.ts
+++ b/src/renderer/api/k8s/statuses.test.ts
@@ -115,4 +115,70 @@ describe("getStatusCategory", () => {
       }),
     ).toBe("NotReady");
   });
+
+  test("prefers NotReady over InProgress when both a terminal failure and an Unknown condition are present", () => {
+    expect(
+      getStatusCategory({
+        status: {
+          conditions: [
+            { type: "Accepted", status: "False", reason: "Invalid" },
+            { type: "Programmed", status: "Unknown", reason: "Pending" },
+          ],
+        },
+      }),
+    ).toBe("NotReady");
+  });
+
+  test.each([
+    "GatewayNotProgrammed",
+    "Reconciling",
+    "NotReconciled",
+    "Waiting",
+    "Pending",
+  ])("treats the transient reason %s as InProgress even when the status is False", (reason) => {
+    expect(
+      getStatusCategory({
+        status: {
+          conditions: [{ type: "Programmed", status: "False", reason }],
+        },
+      }),
+    ).toBe("InProgress");
+  });
+
+  test("treats a mix of True and Unknown conditions (no failures) as InProgress", () => {
+    expect(
+      getStatusCategory({
+        status: {
+          conditions: [
+            { type: "Accepted", status: "True", reason: "Accepted" },
+            { type: "Programmed", status: "Unknown", reason: "Pending" },
+          ],
+        },
+      }),
+    ).toBe("InProgress");
+  });
+
+  test("returns Unknown for a non-object status", () => {
+    expect(getStatusCategory({ status: "ready" })).toBe("Unknown");
+    expect(getStatusCategory({ status: 42 })).toBe("Unknown");
+    expect(getStatusCategory({ status: null })).toBe("Unknown");
+  });
+
+  test("ignores conditions that are missing a status field", () => {
+    expect(
+      getStatusCategory({
+        status: {
+          conditions: [{ type: "Accepted", reason: "Accepted" }],
+        },
+      }),
+    ).toBe("Unknown");
+  });
+
+  test("returns Unknown for empty parents and empty nested condition arrays", () => {
+    expect(getStatusCategory({ status: { parents: [] } })).toBe("Unknown");
+    expect(getStatusCategory({ status: { parents: [{ conditions: [] }] } })).toBe("Unknown");
+    expect(getStatusCategory({ status: { conditions: [{ ancestorRef: { name: "gw" }, conditions: [] }] } })).toBe(
+      "Unknown",
+    );
+  });
 });

--- a/src/renderer/api/k8s/types.test.ts
+++ b/src/renderer/api/k8s/types.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { hasTrueCondition } from "./types";
+
+describe("hasTrueCondition", () => {
+  test("returns true when a matching condition is True", () => {
+    expect(hasTrueCondition([{ type: "Accepted", status: "True" }], "Accepted")).toBe(true);
+  });
+
+  test("returns false when the matching condition is not True", () => {
+    expect(hasTrueCondition([{ type: "Accepted", status: "False" }], "Accepted")).toBe(false);
+    expect(hasTrueCondition([{ type: "Accepted", status: "Unknown" }], "Accepted")).toBe(false);
+  });
+
+  test("returns false when no condition has the requested type", () => {
+    expect(hasTrueCondition([{ type: "Programmed", status: "True" }], "Accepted")).toBe(false);
+  });
+
+  test("matches the requested type among several conditions", () => {
+    expect(
+      hasTrueCondition(
+        [
+          { type: "Accepted", status: "False" },
+          { type: "Programmed", status: "True" },
+        ],
+        "Programmed",
+      ),
+    ).toBe(true);
+  });
+
+  test("returns false for an empty or undefined condition list", () => {
+    expect(hasTrueCondition([], "Accepted")).toBe(false);
+    expect(hasTrueCondition(undefined, "Accepted")).toBe(false);
+  });
+});

--- a/src/renderer/pages/k8s/route-summaries.test.ts
+++ b/src/renderer/pages/k8s/route-summaries.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { formatBackendRefs, formatParentRefs } from "./route-summaries";
+
+describe("formatParentRefs", () => {
+  test("returns a dash for an empty list", () => {
+    expect(formatParentRefs([])).toBe("-");
+  });
+
+  test("defaults a missing kind to Gateway", () => {
+    expect(formatParentRefs([{ name: "my-gateway" }])).toBe("Gateway/my-gateway");
+  });
+
+  test("uses the provided kind when present", () => {
+    expect(formatParentRefs([{ kind: "Mesh", name: "my-mesh" }])).toBe("Mesh/my-mesh");
+  });
+
+  test("joins multiple parent refs with a comma", () => {
+    expect(formatParentRefs([{ name: "gw-a" }, { kind: "Mesh", name: "mesh-b" }])).toBe("Gateway/gw-a, Mesh/mesh-b");
+  });
+});
+
+describe("formatBackendRefs", () => {
+  test("returns a dash for an empty list", () => {
+    expect(formatBackendRefs([])).toBe("-");
+  });
+
+  test("defaults a missing kind to Service", () => {
+    expect(formatBackendRefs([{ name: "my-service" }])).toBe("Service/my-service");
+  });
+
+  test("uses the provided kind when present", () => {
+    expect(formatBackendRefs([{ kind: "Backend", name: "my-backend" }])).toBe("Backend/my-backend");
+  });
+
+  test("joins multiple backend refs with a comma", () => {
+    expect(formatBackendRefs([{ name: "svc-a" }, { kind: "Backend", name: "backend-b" }])).toBe(
+      "Service/svc-a, Backend/backend-b",
+    );
+  });
+});

--- a/src/renderer/pages/k8s/route-summaries.ts
+++ b/src/renderer/pages/k8s/route-summaries.ts
@@ -1,0 +1,15 @@
+export function formatParentRefs(parentRefs: Array<{ kind?: string; name: string }>): string {
+  if (parentRefs.length === 0) {
+    return "-";
+  }
+
+  return parentRefs.map((parentRef) => `${parentRef.kind ?? "Gateway"}/${parentRef.name}`).join(", ");
+}
+
+export function formatBackendRefs(backendRefs: Array<{ kind?: string; name: string }>): string {
+  if (backendRefs.length === 0) {
+    return "-";
+  }
+
+  return backendRefs.map((backendRef) => `${backendRef.kind ?? "Service"}/${backendRef.name}`).join(", ");
+}

--- a/src/renderer/pages/k8s/shared.tsx
+++ b/src/renderer/pages/k8s/shared.tsx
@@ -1,27 +1,13 @@
 import { Renderer } from "@freelensapp/extensions";
 
+export { formatBackendRefs, formatParentRefs } from "./route-summaries";
+
 const {
   Component: { LinkToNamespace, WithTooltip },
 } = Renderer;
 
 export interface GatewayPageProps {
   extension: Renderer.LensExtension;
-}
-
-export function formatParentRefs(parentRefs: Array<{ kind?: string; name: string }>): string {
-  if (parentRefs.length === 0) {
-    return "-";
-  }
-
-  return parentRefs.map((parentRef) => `${parentRef.kind ?? "Gateway"}/${parentRef.name}`).join(", ");
-}
-
-export function formatBackendRefs(backendRefs: Array<{ kind?: string; name: string }>): string {
-  if (backendRefs.length === 0) {
-    return "-";
-  }
-
-  return backendRefs.map((backendRef) => `${backendRef.kind ?? "Service"}/${backendRef.name}`).join(", ");
 }
 
 export function namespaceCell(namespace: string | undefined) {

--- a/src/renderer/pages/k8s/stream-route-derivations.test.ts
+++ b/src/renderer/pages/k8s/stream-route-derivations.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+import { getBackendRefs, getParentRefs, isAccepted } from "./stream-route-derivations";
+
+describe("getParentRefs", () => {
+  test("returns an empty array when there is no spec", () => {
+    expect(getParentRefs({})).toEqual([]);
+    expect(getParentRefs({ spec: {} })).toEqual([]);
+  });
+
+  test("merges commonParentRefs before parentRefs", () => {
+    expect(
+      getParentRefs({
+        spec: {
+          commonParentRefs: [{ name: "common-gw" }],
+          parentRefs: [{ name: "own-gw" }],
+        },
+      }),
+    ).toEqual([{ name: "common-gw" }, { name: "own-gw" }]);
+  });
+
+  test("handles either source being absent", () => {
+    expect(getParentRefs({ spec: { parentRefs: [{ name: "own-gw" }] } })).toEqual([{ name: "own-gw" }]);
+    expect(getParentRefs({ spec: { commonParentRefs: [{ name: "common-gw" }] } })).toEqual([{ name: "common-gw" }]);
+  });
+});
+
+describe("getBackendRefs", () => {
+  test("returns an empty array when there are no rules", () => {
+    expect(getBackendRefs({})).toEqual([]);
+    expect(getBackendRefs({ spec: {} })).toEqual([]);
+    expect(getBackendRefs({ spec: { rules: [] } })).toEqual([]);
+  });
+
+  test("flattens backendRefs across rules", () => {
+    expect(
+      getBackendRefs({
+        spec: {
+          rules: [{ backendRefs: [{ name: "svc-a" }] }, { backendRefs: [{ name: "svc-b" }, { name: "svc-c" }] }],
+        },
+      }),
+    ).toEqual([{ name: "svc-a" }, { name: "svc-b" }, { name: "svc-c" }]);
+  });
+
+  test("ignores rules without backendRefs", () => {
+    expect(
+      getBackendRefs({
+        spec: {
+          rules: [{}, { backendRefs: [{ name: "svc-a" }] }],
+        },
+      }),
+    ).toEqual([{ name: "svc-a" }]);
+  });
+});
+
+describe("isAccepted", () => {
+  test("returns false when there is no status or no parents", () => {
+    expect(isAccepted({})).toBe(false);
+    expect(isAccepted({ status: {} })).toBe(false);
+    expect(isAccepted({ status: { parents: [] } })).toBe(false);
+  });
+
+  test("returns true when any parent has an Accepted=True condition", () => {
+    expect(
+      isAccepted({
+        status: {
+          parents: [
+            { conditions: [{ type: "ResolvedRefs", status: "True" }] },
+            { conditions: [{ type: "Accepted", status: "True" }] },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false when Accepted is present but not True", () => {
+    expect(
+      isAccepted({
+        status: {
+          parents: [{ conditions: [{ type: "Accepted", status: "False" }] }],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false when a parent has no conditions", () => {
+    expect(isAccepted({ status: { parents: [{}] } })).toBe(false);
+  });
+});

--- a/src/renderer/pages/k8s/stream-route-derivations.ts
+++ b/src/renderer/pages/k8s/stream-route-derivations.ts
@@ -1,0 +1,38 @@
+import { type BackendRef, type ParentReference } from "../../api/k8s/types";
+
+export interface HasSpecWithParentRefs {
+  spec?: {
+    parentRefs?: ParentReference[];
+    commonParentRefs?: ParentReference[];
+  };
+}
+
+export interface HasSpecWithRules {
+  spec?: {
+    rules?: Array<{ backendRefs?: BackendRef[] }>;
+  };
+}
+
+export interface HasStatusWithParents {
+  status?: {
+    parents?: Array<{
+      conditions?: Array<{ type: string; status: string }>;
+    }>;
+  };
+}
+
+export function getParentRefs(item: HasSpecWithParentRefs): ParentReference[] {
+  const spec = item.spec ?? {};
+
+  return [...(spec.commonParentRefs ?? []), ...(spec.parentRefs ?? [])];
+}
+
+export function getBackendRefs(item: HasSpecWithRules): BackendRef[] {
+  return (item.spec?.rules ?? []).flatMap((rule) => rule?.backendRefs ?? []);
+}
+
+export function isAccepted(item: HasStatusWithParents): boolean {
+  return (item.status?.parents ?? []).some((parent) =>
+    (parent?.conditions ?? []).some((condition) => condition.type === "Accepted" && condition.status === "True"),
+  );
+}

--- a/src/renderer/pages/k8s/stream-route-page-factory.tsx
+++ b/src/renderer/pages/k8s/stream-route-page-factory.tsx
@@ -1,49 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { type BackendRef, type ParentReference } from "../../api/k8s/types";
 import { withErrorPage } from "../../components/error-page";
 import { observer } from "../../observer";
 import { formatBackendRefs, formatParentRefs, type GatewayPageProps, namespaceCell } from "./shared";
+import { getBackendRefs, getParentRefs, isAccepted } from "./stream-route-derivations";
 
 const {
   Component: { BadgeBoolean, KubeObjectAge, KubeObjectListLayout, WithTooltip },
 } = Renderer;
-
-interface HasSpecWithParentRefs {
-  spec?: {
-    parentRefs?: ParentReference[];
-    commonParentRefs?: ParentReference[];
-  };
-}
-
-interface HasSpecWithRules {
-  spec?: {
-    rules?: Array<{ backendRefs?: BackendRef[] }>;
-  };
-}
-
-interface HasStatusWithParents {
-  status?: {
-    parents?: Array<{
-      conditions?: Array<{ type: string; status: string }>;
-    }>;
-  };
-}
-
-function getParentRefs(item: HasSpecWithParentRefs): ParentReference[] {
-  const spec = item.spec ?? {};
-
-  return [...(spec.commonParentRefs ?? []), ...(spec.parentRefs ?? [])];
-}
-
-function getBackendRefs(item: HasSpecWithRules): BackendRef[] {
-  return (item.spec?.rules ?? []).flatMap((rule) => rule?.backendRefs ?? []);
-}
-
-function isAccepted(item: HasStatusWithParents): boolean {
-  return (item.status?.parents ?? []).some((parent) =>
-    (parent?.conditions ?? []).some((condition) => condition.type === "Accepted" && condition.status === "True"),
-  );
-}
 
 export function createStreamRoutePage<T extends Renderer.K8sApi.LensExtensionKubeObject<any, any, any>>(
   KubeObject: {

--- a/src/renderer/utils.test.ts
+++ b/src/renderer/utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { createHash } from "./utils";
+
+describe("createHash", () => {
+  test("is a 16-character lowercase hex string", () => {
+    expect(createHash({ a: 1 })).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("is stable for equal input", () => {
+    expect(createHash({ a: 1 })).toBe(createHash({ a: 1 }));
+  });
+
+  test("differs for different input", () => {
+    expect(createHash({ a: 1 })).not.toBe(createHash({ a: 2 }));
+  });
+
+  test("is sensitive to key order, matching JSON.stringify semantics", () => {
+    expect(createHash({ a: 1, b: 2 })).not.toBe(createHash({ b: 2, a: 1 }));
+  });
+
+  test("handles primitive and array input", () => {
+    expect(createHash("hello")).toMatch(/^[0-9a-f]{16}$/);
+    expect(createHash([1, 2, 3])).toMatch(/^[0-9a-f]{16}$/);
+  });
+});


### PR DESCRIPTION
Implements the unit test proposal from #54.

- Tests for `hasTrueCondition`, `maybe`, and `createHash`
- Extracted route summary helpers and stream-route derivations into pure modules with tests
- Strengthened `getStatusCategory` tests (precedence, transient reasons, malformed input)

59 tests passing; type-check and build clean.

Closes #54