### PR TITLE
Add v1 API version for TCPRoute and UDPRoute

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ conditions, spec fields, and related objects displayed in the detail view.
 | v1 | `HTTPRoute` | | Namespaced | Routes HTTP and HTTPS traffic to backends |
 | v1 | `GRPCRoute` | | Namespaced | Routes gRPC traffic to backends |
 | v1 | `TLSRoute` | | Namespaced | Routes TLS traffic to backends based on SNI |
+| v1 | `TCPRoute` | | Namespaced | Routes TCP traffic to backends |
+| v1 | `UDPRoute` | | Namespaced | Routes UDP traffic to backends |
 | v1 | `BackendTLSPolicy` | `btlspolicy` | Namespaced | Configures TLS for connections from a Gateway to backends |
 | v1 | `ReferenceGrant` | `refgrant` | Namespaced | Allows cross-namespace references to Gateway API resources |
 | v1 | `ListenerSet` | `lset` | Namespaced | Extends a Gateway with additional listeners |
-| v1alpha2 | `TCPRoute` | | Namespaced | Routes TCP traffic to backends |
-| v1alpha2 | `UDPRoute` | | Namespaced | Routes UDP traffic to backends |
+| v1alpha2 | `TCPRoute` | | Namespaced | Routes TCP traffic to backends (v1alpha2 variant) |
+| v1alpha2 | `UDPRoute` | | Namespaced | Routes UDP traffic to backends (v1alpha2 variant) |
 | v1beta1 | `ReferenceGrant` | `refgrant` | Namespaced | Allows cross-namespace references (v1beta1 variant) |
 
 <!-- markdownlint-enable MD013 -->

--- a/src/renderer/api/k8s/index.ts
+++ b/src/renderer/api/k8s/index.ts
@@ -35,6 +35,11 @@ import {
   ReferenceGrantStore as ReferenceGrantStore_v1beta1,
 } from "./reference-grant-v1beta1";
 import {
+  TCPRoute as TCPRoute_v1,
+  TCPRouteApi as TCPRouteApi_v1,
+  TCPRouteStore as TCPRouteStore_v1,
+} from "./tcp-route-v1";
+import {
   TCPRoute as TCPRoute_v1alpha2,
   TCPRouteApi as TCPRouteApi_v1alpha2,
   TCPRouteStore as TCPRouteStore_v1alpha2,
@@ -44,6 +49,11 @@ import {
   TLSRouteApi as TLSRouteApi_v1,
   TLSRouteStore as TLSRouteStore_v1,
 } from "./tls-route-v1";
+import {
+  UDPRoute as UDPRoute_v1,
+  UDPRouteApi as UDPRouteApi_v1,
+  UDPRouteStore as UDPRouteStore_v1,
+} from "./udp-route-v1";
 import {
   UDPRoute as UDPRoute_v1alpha2,
   UDPRouteApi as UDPRouteApi_v1alpha2,
@@ -98,22 +108,28 @@ export {
   ReferenceGrantStore_v1,
   ReferenceGrantStore_v1 as ReferenceGrantStore,
   ReferenceGrantStore_v1beta1,
+  TCPRoute_v1,
+  TCPRoute_v1 as TCPRoute,
   TCPRoute_v1alpha2,
-  TCPRoute_v1alpha2 as TCPRoute,
+  TCPRouteApi_v1,
+  TCPRouteApi_v1 as TCPRouteApi,
   TCPRouteApi_v1alpha2,
-  TCPRouteApi_v1alpha2 as TCPRouteApi,
+  TCPRouteStore_v1,
+  TCPRouteStore_v1 as TCPRouteStore,
   TCPRouteStore_v1alpha2,
-  TCPRouteStore_v1alpha2 as TCPRouteStore,
   TLSRoute_v1,
   TLSRoute_v1 as TLSRoute,
   TLSRouteApi_v1,
   TLSRouteApi_v1 as TLSRouteApi,
   TLSRouteStore_v1,
   TLSRouteStore_v1 as TLSRouteStore,
+  UDPRoute_v1,
+  UDPRoute_v1 as UDPRoute,
   UDPRoute_v1alpha2,
-  UDPRoute_v1alpha2 as UDPRoute,
+  UDPRouteApi_v1,
+  UDPRouteApi_v1 as UDPRouteApi,
   UDPRouteApi_v1alpha2,
-  UDPRouteApi_v1alpha2 as UDPRouteApi,
+  UDPRouteStore_v1,
+  UDPRouteStore_v1 as UDPRouteStore,
   UDPRouteStore_v1alpha2,
-  UDPRouteStore_v1alpha2 as UDPRouteStore,
 };

--- a/src/renderer/api/k8s/tcp-route-v1.ts
+++ b/src/renderer/api/k8s/tcp-route-v1.ts
@@ -1,0 +1,32 @@
+import { Renderer } from "@freelensapp/extensions";
+import { type BackendRef, type CommonRouteSpec, type GatewayKubeObjectCRD, type RouteStatus } from "./types";
+
+export interface TCPRouteRule {
+  name?: string;
+  backendRefs?: BackendRef[];
+}
+
+export interface TCPRouteSpec extends CommonRouteSpec {
+  rules: TCPRouteRule[];
+}
+
+export interface TCPRouteStatus extends RouteStatus {}
+
+export class TCPRoute extends Renderer.K8sApi.LensExtensionKubeObject<
+  Renderer.K8sApi.KubeObjectMetadata,
+  TCPRouteStatus,
+  TCPRouteSpec
+> {
+  static readonly kind = "TCPRoute";
+  static readonly namespaced = true;
+  static readonly apiBase = "/apis/gateway.networking.k8s.io/v1/tcproutes";
+  static readonly crd: GatewayKubeObjectCRD = {
+    apiVersions: ["gateway.networking.k8s.io/v1"],
+    plural: "tcproutes",
+    singular: "tcproute",
+    title: "TCP Routes",
+  };
+}
+
+export class TCPRouteApi extends Renderer.K8sApi.KubeApi<TCPRoute> {}
+export class TCPRouteStore extends Renderer.K8sApi.KubeObjectStore<TCPRoute, TCPRouteApi> {}

--- a/src/renderer/api/k8s/udp-route-v1.ts
+++ b/src/renderer/api/k8s/udp-route-v1.ts
@@ -1,0 +1,32 @@
+import { Renderer } from "@freelensapp/extensions";
+import { type BackendRef, type CommonRouteSpec, type GatewayKubeObjectCRD, type RouteStatus } from "./types";
+
+export interface UDPRouteRule {
+  name?: string;
+  backendRefs?: BackendRef[];
+}
+
+export interface UDPRouteSpec extends CommonRouteSpec {
+  rules?: UDPRouteRule[];
+}
+
+export interface UDPRouteStatus extends RouteStatus {}
+
+export class UDPRoute extends Renderer.K8sApi.LensExtensionKubeObject<
+  Renderer.K8sApi.KubeObjectMetadata,
+  UDPRouteStatus,
+  UDPRouteSpec
+> {
+  static readonly kind = "UDPRoute";
+  static readonly namespaced = true;
+  static readonly apiBase = "/apis/gateway.networking.k8s.io/v1/udproutes";
+  static readonly crd: GatewayKubeObjectCRD = {
+    apiVersions: ["gateway.networking.k8s.io/v1"],
+    plural: "udproutes",
+    singular: "udproute",
+    title: "UDP Routes",
+  };
+}
+
+export class UDPRouteApi extends Renderer.K8sApi.KubeApi<UDPRoute> {}
+export class UDPRouteStore extends Renderer.K8sApi.KubeObjectStore<UDPRoute, UDPRouteApi> {}

--- a/src/renderer/details/k8s/index.ts
+++ b/src/renderer/details/k8s/index.ts
@@ -6,8 +6,10 @@ import { HTTPRouteDetails as HTTPRouteDetails_v1 } from "./http-route-details-v1
 import { ListenerSetDetails as ListenerSetDetails_v1 } from "./listener-set-details-v1";
 import { ReferenceGrantDetails as ReferenceGrantDetails_v1 } from "./reference-grant-details-v1";
 import { ReferenceGrantDetails as ReferenceGrantDetails_v1beta1 } from "./reference-grant-details-v1beta1";
+import { TCPRouteDetails as TCPRouteDetails_v1 } from "./tcp-route-details-v1";
 import { TCPRouteDetails as TCPRouteDetails_v1alpha2 } from "./tcp-route-details-v1alpha2";
 import { TLSRouteDetails as TLSRouteDetails_v1 } from "./tls-route-details-v1";
+import { UDPRouteDetails as UDPRouteDetails_v1 } from "./udp-route-details-v1";
 import { UDPRouteDetails as UDPRouteDetails_v1alpha2 } from "./udp-route-details-v1alpha2";
 
 export {
@@ -19,8 +21,10 @@ export {
   ListenerSetDetails_v1,
   ReferenceGrantDetails_v1,
   ReferenceGrantDetails_v1beta1,
+  TCPRouteDetails_v1,
   TCPRouteDetails_v1alpha2,
   TLSRouteDetails_v1,
+  UDPRouteDetails_v1,
   UDPRouteDetails_v1alpha2,
 };
 
@@ -31,6 +35,6 @@ export const GRPCRouteDetails = GRPCRouteDetails_v1;
 export const HTTPRouteDetails = HTTPRouteDetails_v1;
 export const ListenerSetDetails = ListenerSetDetails_v1;
 export const ReferenceGrantDetails = ReferenceGrantDetails_v1;
-export const TCPRouteDetails = TCPRouteDetails_v1alpha2;
+export const TCPRouteDetails = TCPRouteDetails_v1;
 export const TLSRouteDetails = TLSRouteDetails_v1;
-export const UDPRouteDetails = UDPRouteDetails_v1alpha2;
+export const UDPRouteDetails = UDPRouteDetails_v1;

--- a/src/renderer/details/k8s/tcp-route-details-v1.tsx
+++ b/src/renderer/details/k8s/tcp-route-details-v1.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { TCPRoute } from "../../api/k8s/tcp-route-v1alpha2";
+import { TCPRoute } from "../../api/k8s/tcp-route-v1";
 import { observer } from "../../observer";
 import { createHash } from "../../utils";
 import styles from "./common.module.scss";

--- a/src/renderer/details/k8s/udp-route-details-v1.tsx
+++ b/src/renderer/details/k8s/udp-route-details-v1.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { TCPRoute } from "../../api/k8s/tcp-route-v1alpha2";
+import { UDPRoute } from "../../api/k8s/udp-route-v1";
 import { observer } from "../../observer";
 import { createHash } from "../../utils";
 import styles from "./common.module.scss";
@@ -9,13 +9,13 @@ const {
   Component: { BadgeBoolean, DrawerItem, DrawerTitle, LinkToObject, Icon, Table, TableCell, TableHead, TableRow },
 } = Renderer;
 
-function isAccepted(object: TCPRoute): boolean {
+function isAccepted(object: UDPRoute): boolean {
   return (object.status?.parents ?? []).some((parent) =>
     (parent?.conditions ?? []).some((condition) => condition?.type === "Accepted" && condition?.status === "True"),
   );
 }
 
-export const TCPRouteDetails = observer((props: Renderer.Component.KubeObjectDetailsProps<TCPRoute>) => {
+export const UDPRouteDetails = observer((props: Renderer.Component.KubeObjectDetailsProps<UDPRoute>) => {
   const { object } = props;
   const objectNs = object.getNs();
 

--- a/src/renderer/details/k8s/udp-route-details-v1alpha2.tsx
+++ b/src/renderer/details/k8s/udp-route-details-v1alpha2.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { UDPRoute } from "../../api/k8s";
+import { UDPRoute } from "../../api/k8s/udp-route-v1alpha2";
 import { observer } from "../../observer";
 import { createHash } from "../../utils";
 import styles from "./common.module.scss";

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -12,8 +12,10 @@ import { HTTPRoute as HTTPRoute_v1 } from "./api/k8s/http-route-v1";
 import { ListenerSet as ListenerSet_v1 } from "./api/k8s/listenerset-v1";
 import { ReferenceGrant as ReferenceGrant_v1 } from "./api/k8s/reference-grant-v1";
 import { ReferenceGrant as ReferenceGrant_v1beta1 } from "./api/k8s/reference-grant-v1beta1";
+import { TCPRoute as TCPRoute_v1 } from "./api/k8s/tcp-route-v1";
 import { TCPRoute as TCPRoute_v1alpha2 } from "./api/k8s/tcp-route-v1alpha2";
 import { TLSRoute as TLSRoute_v1 } from "./api/k8s/tls-route-v1";
+import { UDPRoute as UDPRoute_v1 } from "./api/k8s/udp-route-v1";
 import { UDPRoute as UDPRoute_v1alpha2 } from "./api/k8s/udp-route-v1alpha2";
 import { XBackendTrafficPolicy as XBackendTrafficPolicy_v1alpha1 } from "./api/x-k8s/x-backend-traffic-policy-v1alpha1";
 import { XMesh as XMesh_v1alpha1 } from "./api/x-k8s/xmesh-v1alpha1";
@@ -26,8 +28,10 @@ import { HTTPRouteDetails as HTTPRouteDetails_v1 } from "./details/k8s/http-rout
 import { ListenerSetDetails as ListenerSetDetails_v1 } from "./details/k8s/listener-set-details-v1";
 import { ReferenceGrantDetails as ReferenceGrantDetails_v1 } from "./details/k8s/reference-grant-details-v1";
 import { ReferenceGrantDetails as ReferenceGrantDetails_v1beta1 } from "./details/k8s/reference-grant-details-v1beta1";
+import { TCPRouteDetails as TCPRouteDetails_v1 } from "./details/k8s/tcp-route-details-v1";
 import { TCPRouteDetails as TCPRouteDetails_v1alpha2 } from "./details/k8s/tcp-route-details-v1alpha2";
 import { TLSRouteDetails as TLSRouteDetails_v1 } from "./details/k8s/tls-route-details-v1";
+import { UDPRouteDetails as UDPRouteDetails_v1 } from "./details/k8s/udp-route-details-v1";
 import { UDPRouteDetails as UDPRouteDetails_v1alpha2 } from "./details/k8s/udp-route-details-v1alpha2";
 import { XBackendTrafficPolicyDetails as XBackendTrafficPolicyDetails_v1alpha1 } from "./details/x-k8s/x-backend-traffic-policy-details-v1alpha1";
 import { XMeshDetails as XMeshDetails_v1alpha1 } from "./details/x-k8s/xmesh-details-v1alpha1";
@@ -40,8 +44,10 @@ import { HTTPRoutesPage as HTTPRoutesPage_v1 } from "./pages/k8s/http-routes-pag
 import { ListenerSetsPage as ListenerSetsPage_v1 } from "./pages/k8s/listener-sets-page-v1";
 import { ReferenceGrantsPage as ReferenceGrantsPage_v1 } from "./pages/k8s/reference-grants/reference-grants-page-v1";
 import { ReferenceGrantsPage as ReferenceGrantsPage_v1beta1 } from "./pages/k8s/reference-grants/reference-grants-page-v1beta1";
+import { TCPRoutesPage as TCPRoutesPage_v1 } from "./pages/k8s/tcp-routes-page-v1";
 import { TCPRoutesPage as TCPRoutesPage_v1alpha2 } from "./pages/k8s/tcp-routes-page-v1alpha2";
 import { TLSRoutesPage as TLSRoutesPage_v1 } from "./pages/k8s/tls-routes-page-v1";
+import { UDPRoutesPage as UDPRoutesPage_v1 } from "./pages/k8s/udp-routes-page-v1";
 import { UDPRoutesPage as UDPRoutesPage_v1alpha2 } from "./pages/k8s/udp-routes-page-v1alpha2";
 import { OverviewPage } from "./pages/overview";
 import { XBackendTrafficPoliciesPage as XBackendTrafficPoliciesPage_v1alpha1 } from "./pages/x-k8s/x-backend-traffic-policies-page-v1alpha1";
@@ -84,6 +90,14 @@ export default class GatewayApiRenderer extends Renderer.LensExtension {
       },
     },
     {
+      kind: TCPRoute_v1.kind,
+      apiVersions: TCPRoute_v1.crd.apiVersions,
+      priority: 10,
+      components: {
+        Details: (props: Renderer.Component.KubeObjectDetailsProps<any>) => <TCPRouteDetails_v1 {...props} />,
+      },
+    },
+    {
       kind: TCPRoute_v1alpha2.kind,
       apiVersions: TCPRoute_v1alpha2.crd.apiVersions,
       priority: 10,
@@ -97,6 +111,14 @@ export default class GatewayApiRenderer extends Renderer.LensExtension {
       priority: 10,
       components: {
         Details: (props: Renderer.Component.KubeObjectDetailsProps<any>) => <TLSRouteDetails_v1 {...props} />,
+      },
+    },
+    {
+      kind: UDPRoute_v1.kind,
+      apiVersions: UDPRoute_v1.crd.apiVersions,
+      priority: 10,
+      components: {
+        Details: (props: Renderer.Component.KubeObjectDetailsProps<any>) => <UDPRouteDetails_v1 {...props} />,
       },
     },
     {
@@ -204,6 +226,7 @@ export default class GatewayApiRenderer extends Renderer.LensExtension {
       id: "tcproute",
       components: {
         Page: createAvailableVersionPage("TCP Routes", [
+          { kubeObjectClass: TCPRoute_v1, PageComponent: TCPRoutesPage_v1, version: "v1" },
           { kubeObjectClass: TCPRoute_v1alpha2, PageComponent: TCPRoutesPage_v1alpha2, version: "v1alpha2" },
         ]),
       },
@@ -220,6 +243,7 @@ export default class GatewayApiRenderer extends Renderer.LensExtension {
       id: "udproute",
       components: {
         Page: createAvailableVersionPage("UDP Routes", [
+          { kubeObjectClass: UDPRoute_v1, PageComponent: UDPRoutesPage_v1, version: "v1" },
           { kubeObjectClass: UDPRoute_v1alpha2, PageComponent: UDPRoutesPage_v1alpha2, version: "v1alpha2" },
         ]),
       },

--- a/src/renderer/pages/k8s/index.ts
+++ b/src/renderer/pages/k8s/index.ts
@@ -6,8 +6,10 @@ import { HTTPRoutesPage as HTTPRoutesPage_v1 } from "./http-routes-page-v1";
 import { ListenerSetsPage as ListenerSetsPage_v1 } from "./listener-sets-page-v1";
 import { ReferenceGrantsPage as ReferenceGrantsPage_v1 } from "./reference-grants/reference-grants-page-v1";
 import { ReferenceGrantsPage as ReferenceGrantsPage_v1beta1 } from "./reference-grants/reference-grants-page-v1beta1";
+import { TCPRoutesPage as TCPRoutesPage_v1 } from "./tcp-routes-page-v1";
 import { TCPRoutesPage as TCPRoutesPage_v1alpha2 } from "./tcp-routes-page-v1alpha2";
 import { TLSRoutesPage as TLSRoutesPage_v1 } from "./tls-routes-page-v1";
+import { UDPRoutesPage as UDPRoutesPage_v1 } from "./udp-routes-page-v1";
 import { UDPRoutesPage as UDPRoutesPage_v1alpha2 } from "./udp-routes-page-v1alpha2";
 
 export {
@@ -19,8 +21,10 @@ export {
   ListenerSetsPage_v1,
   ReferenceGrantsPage_v1,
   ReferenceGrantsPage_v1beta1,
+  TCPRoutesPage_v1,
   TCPRoutesPage_v1alpha2,
   TLSRoutesPage_v1,
+  UDPRoutesPage_v1,
   UDPRoutesPage_v1alpha2,
 };
 
@@ -31,8 +35,8 @@ export const GRPCRoutesPage = GRPCRoutesPage_v1;
 export const HTTPRoutesPage = HTTPRoutesPage_v1;
 export const ListenerSetsPage = ListenerSetsPage_v1;
 export const ReferenceGrantsPage = ReferenceGrantsPage_v1;
-export const TCPRoutesPage = TCPRoutesPage_v1alpha2;
+export const TCPRoutesPage = TCPRoutesPage_v1;
 export const TLSRoutesPage = TLSRoutesPage_v1;
-export const UDPRoutesPage = UDPRoutesPage_v1alpha2;
+export const UDPRoutesPage = UDPRoutesPage_v1;
 
 export * from "./shared";

--- a/src/renderer/pages/k8s/tcp-routes-page-v1.module.d.scss.ts
+++ b/src/renderer/pages/k8s/tcp-routes-page-v1.module.d.scss.ts
@@ -1,0 +1,9 @@
+declare const classNames: {
+  readonly page: "page";
+  readonly tableCell: "tableCell";
+  readonly name: "name";
+  readonly namespace: "namespace";
+  readonly accepted: "accepted";
+  readonly age: "age";
+};
+export = classNames;

--- a/src/renderer/pages/k8s/tcp-routes-page-v1.module.scss
+++ b/src/renderer/pages/k8s/tcp-routes-page-v1.module.scss
@@ -1,0 +1,19 @@
+.page {
+  :global(.TableCell) {
+    &.name {
+      flex-grow: 1.3;
+    }
+
+    &.namespace {
+      flex-grow: 1.3;
+    }
+
+    &.accepted {
+      flex-grow: 0.5;
+    }
+
+    &.age {
+      flex-grow: 0.3;
+    }
+  }
+}

--- a/src/renderer/pages/k8s/tcp-routes-page-v1.tsx
+++ b/src/renderer/pages/k8s/tcp-routes-page-v1.tsx
@@ -1,10 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { TCPRoute } from "../../api/k8s/tcp-route-v1alpha2";
+import { TCPRoute } from "../../api/k8s/tcp-route-v1";
 import { withErrorPage } from "../../components/error-page";
 import { observer } from "../../observer";
 import { type GatewayPageProps, namespaceCell } from "./shared";
-import styles from "./tcp-routes-page-v1alpha2.module.scss";
-import stylesInline from "./tcp-routes-page-v1alpha2.module.scss?inline";
+import styles from "./tcp-routes-page-v1.module.scss";
+import stylesInline from "./tcp-routes-page-v1.module.scss?inline";
 
 const {
   Component: { BadgeBoolean, KubeObjectAge, KubeObjectListLayout, WithTooltip },

--- a/src/renderer/pages/k8s/udp-routes-page-v1.module.d.scss.ts
+++ b/src/renderer/pages/k8s/udp-routes-page-v1.module.d.scss.ts
@@ -1,0 +1,9 @@
+declare const classNames: {
+  readonly page: "page";
+  readonly tableCell: "tableCell";
+  readonly name: "name";
+  readonly namespace: "namespace";
+  readonly accepted: "accepted";
+  readonly age: "age";
+};
+export = classNames;

--- a/src/renderer/pages/k8s/udp-routes-page-v1.module.scss
+++ b/src/renderer/pages/k8s/udp-routes-page-v1.module.scss
@@ -1,0 +1,19 @@
+.page {
+  :global(.TableCell) {
+    &.name {
+      flex-grow: 1.3;
+    }
+
+    &.namespace {
+      flex-grow: 1.3;
+    }
+
+    &.accepted {
+      flex-grow: 0.5;
+    }
+
+    &.age {
+      flex-grow: 0.3;
+    }
+  }
+}

--- a/src/renderer/pages/k8s/udp-routes-page-v1.tsx
+++ b/src/renderer/pages/k8s/udp-routes-page-v1.tsx
@@ -1,16 +1,16 @@
 import { Renderer } from "@freelensapp/extensions";
-import { TCPRoute } from "../../api/k8s/tcp-route-v1alpha2";
+import { UDPRoute } from "../../api/k8s/udp-route-v1";
 import { withErrorPage } from "../../components/error-page";
 import { observer } from "../../observer";
 import { type GatewayPageProps, namespaceCell } from "./shared";
-import styles from "./tcp-routes-page-v1alpha2.module.scss";
-import stylesInline from "./tcp-routes-page-v1alpha2.module.scss?inline";
+import styles from "./udp-routes-page-v1.module.scss";
+import stylesInline from "./udp-routes-page-v1.module.scss?inline";
 
 const {
   Component: { BadgeBoolean, KubeObjectAge, KubeObjectListLayout, WithTooltip },
 } = Renderer;
 
-function isAccepted(item: TCPRoute): boolean {
+function isAccepted(item: UDPRoute): boolean {
   return (
     item.status?.parents?.some((parent) =>
       parent.conditions?.some((condition) => condition.type === "Accepted" && condition.status === "True"),
@@ -18,32 +18,32 @@ function isAccepted(item: TCPRoute): boolean {
   );
 }
 
-export const TCPRoutesPage = observer((props: GatewayPageProps) =>
+export const UDPRoutesPage = observer((props: GatewayPageProps) =>
   withErrorPage(props, () => {
-    const store = TCPRoute.getStore<TCPRoute>();
+    const store = UDPRoute.getStore<UDPRoute>();
 
     return (
       <>
         <style>{stylesInline}</style>
-        <KubeObjectListLayout<TCPRoute, any>
-          tableId={`${TCPRoute.crd.plural}Table`}
+        <KubeObjectListLayout<UDPRoute, any>
+          tableId={`${UDPRoute.crd.plural}Table`}
           className={styles.page}
           store={store}
           sortingCallbacks={{
-            name: (item: TCPRoute) => item.getName(),
-            namespace: (item: TCPRoute) => item.getNs() ?? "",
-            accepted: (item: TCPRoute) => String(isAccepted(item)),
-            age: (item: TCPRoute) => item.getCreationTimestamp(),
+            name: (item: UDPRoute) => item.getName(),
+            namespace: (item: UDPRoute) => item.getNs() ?? "",
+            accepted: (item: UDPRoute) => String(isAccepted(item)),
+            age: (item: UDPRoute) => item.getCreationTimestamp(),
           }}
-          searchFilters={[(item: TCPRoute) => item.getSearchFields()]}
-          renderHeaderTitle={TCPRoute.crd.title}
+          searchFilters={[(item: UDPRoute) => item.getSearchFields()]}
+          renderHeaderTitle={UDPRoute.crd.title}
           renderTableHeader={[
             { title: "Name", sortBy: "name", className: styles.name },
             { title: "Namespace", sortBy: "namespace", className: styles.namespace },
             { title: "Accepted", sortBy: "accepted", className: styles.accepted },
             { title: "Age", sortBy: "age", className: styles.age },
           ]}
-          renderTableContents={(item: TCPRoute) => [
+          renderTableContents={(item: UDPRoute) => [
             <WithTooltip>{item.getName()}</WithTooltip>,
             namespaceCell(item.getNs()),
             <BadgeBoolean value={isAccepted(item)} />,

--- a/src/renderer/pages/k8s/udp-routes-page-v1alpha2.tsx
+++ b/src/renderer/pages/k8s/udp-routes-page-v1alpha2.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { UDPRoute } from "../../api/k8s";
+import { UDPRoute } from "../../api/k8s/udp-route-v1alpha2";
 import { withErrorPage } from "../../components/error-page";
 import { observer } from "../../observer";
 import { type GatewayPageProps, namespaceCell } from "./shared";

--- a/src/renderer/pages/overview.tsx
+++ b/src/renderer/pages/overview.tsx
@@ -7,9 +7,11 @@ import {
   GRPCRoute as GRPCRoute_v1,
   HTTPRoute as HTTPRoute_v1,
   ListenerSet as ListenerSet_v1,
-  TCPRoute as TCPRoute_v1alpha2,
+  TCPRoute_v1,
+  TCPRoute_v1alpha2,
   TLSRoute as TLSRoute_v1,
-  UDPRoute as UDPRoute_v1alpha2,
+  UDPRoute_v1,
+  UDPRoute_v1alpha2,
 } from "../api/k8s";
 import { XBackendTrafficPolicy as XBackendTrafficPolicy_v1alpha1, XMesh as XMesh_v1alpha1 } from "../api/x-k8s";
 import { GatewayApiEvents } from "../components/gateway-api-events";
@@ -34,8 +36,10 @@ const resources = [
   Gateway_v1,
   HTTPRoute_v1,
   GRPCRoute_v1,
+  TCPRoute_v1,
   TCPRoute_v1alpha2,
   TLSRoute_v1,
+  UDPRoute_v1,
   UDPRoute_v1alpha2,
   ListenerSet_v1,
   BackendTLSPolicy_v1,


### PR DESCRIPTION
Adds the graduated `gateway.networking.k8s.io/v1` version for `TCPRoute` and `UDPRoute` (Gateway API v1.6.0) alongside the existing `v1alpha2` models, with list and detail views. The available-version pages and overview prefer v1 and fall back to v1alpha2.

Closes #65
