### PR TITLE
Remove duplicate Hostnames row in HTTPRoute details

### DIFF
--- a/src/renderer/details/k8s/grpc-route-details-v1.tsx
+++ b/src/renderer/details/k8s/grpc-route-details-v1.tsx
@@ -19,7 +19,6 @@ export const GRPCRouteDetails = observer((props: Renderer.Component.KubeObjectDe
   const { object } = props;
   const objectNs = object.getNs();
 
-  const hostnames = object.spec?.hostnames ?? [];
   const parentRefs = object.spec?.parentRefs ?? [];
   const rules = object.spec?.rules ?? [];
   const accepted = isAccepted(object);
@@ -28,7 +27,6 @@ export const GRPCRouteDetails = observer((props: Renderer.Component.KubeObjectDe
     <>
       <style>{stylesInline}</style>
       <div className={styles.details}>
-        {hostnames.length > 0 && <DrawerItem name="Hostnames">{hostnames.join(", ") || "*"}</DrawerItem>}
         <DrawerItem name="Accepted">
           <BadgeBoolean value={accepted} />
         </DrawerItem>

--- a/src/renderer/details/k8s/http-route-details-v1.tsx
+++ b/src/renderer/details/k8s/http-route-details-v1.tsx
@@ -19,7 +19,6 @@ export const HTTPRouteDetails = observer((props: Renderer.Component.KubeObjectDe
   const { object } = props;
   const objectNs = object.getNs();
 
-  const hostnames = object.spec?.hostnames ?? [];
   const parentRefs = object.spec?.parentRefs ?? [];
   const rules = object.spec?.rules ?? [];
   const accepted = isAccepted(object);
@@ -28,7 +27,6 @@ export const HTTPRouteDetails = observer((props: Renderer.Component.KubeObjectDe
     <>
       <style>{stylesInline}</style>
       <div className={styles.details}>
-        {hostnames.length > 0 && <DrawerItem name="Hostnames">{hostnames.join(", ") || "*"}</DrawerItem>}
         <DrawerItem name="Accepted">
           <BadgeBoolean value={accepted} />
         </DrawerItem>


### PR DESCRIPTION
## Summary
- remove the extra Hostnames drawer item from HTTPRoute details

## Result
HTTPRoute details no longer displays Hostnames twice.