### PR TITLE
Make HTTPRoute rules clickable

### DIFF
--- a/src/renderer/pages/k8s/http-route-links.test.ts
+++ b/src/renderer/pages/k8s/http-route-links.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import { getHTTPRouteLinks } from "./http-route-links";
+
+function route(spec: Parameters<typeof getHTTPRouteLinks>[0]["spec"] = {}) {
+  return {
+    getNs: () => "apps",
+    spec,
+  };
+}
+
+function gateway(
+  name: string,
+  listeners: NonNullable<Parameters<typeof getHTTPRouteLinks>[1][number]["spec"]>["listeners"],
+  namespace = "apps",
+) {
+  return {
+    getName: () => name,
+    getNs: () => namespace,
+    spec: { listeners },
+  };
+}
+
+describe("getHTTPRouteLinks", () => {
+  test("returns no links when the route has no hostnames", () => {
+    expect(getHTTPRouteLinks(route(), [])).toEqual([]);
+  });
+
+  test("uses an HTTP root URL when no Gateway is available", () => {
+    expect(getHTTPRouteLinks(route({ hostnames: ["app.example.com"] }), [])).toEqual([
+      { displayAsLink: true, url: "http://app.example.com/" },
+    ]);
+  });
+
+  test("includes unique non-regex match paths", () => {
+    expect(
+      getHTTPRouteLinks(
+        route({
+          hostnames: ["app.example.com"],
+          rules: [
+            { matches: [{ path: { type: "PathPrefix", value: "/admin" } }, { path: { value: "/" } }] },
+            { matches: [{ path: { type: "RegularExpression", value: "/users/[0-9]+" } }] },
+          ],
+        }),
+        [],
+      ),
+    ).toEqual([
+      { displayAsLink: true, url: "http://app.example.com/admin" },
+      { displayAsLink: true, url: "http://app.example.com/" },
+    ]);
+  });
+
+  test("uses matching Gateway listener protocols and ports", () => {
+    expect(
+      getHTTPRouteLinks(
+        route({
+          hostnames: ["app.example.com"],
+          parentRefs: [
+            { name: "public", sectionName: "websecure" },
+            { name: "public", port: 8080 },
+          ],
+        }),
+        [
+          gateway("public", [
+            { name: "web", port: 8080, protocol: "HTTP" },
+            { name: "websecure", port: 443, protocol: "HTTPS" },
+            { name: "tcp", port: 9000, protocol: "TCP" },
+          ]),
+        ],
+      ),
+    ).toEqual([
+      { displayAsLink: true, url: "https://app.example.com/" },
+      { displayAsLink: true, url: "http://app.example.com:8080/" },
+    ]);
+  });
+
+  test("matches the referenced Gateway namespace and listener hostname", () => {
+    expect(
+      getHTTPRouteLinks(
+        route({
+          hostnames: ["app.example.com"],
+          parentRefs: [{ name: "public", namespace: "infra" }],
+        }),
+        [
+          gateway("public", [{ name: "wrong-host", hostname: "other.example.com", port: 443, protocol: "HTTPS" }]),
+          gateway("public", [{ name: "wildcard", hostname: "*.example.com", port: 8443, protocol: "HTTPS" }], "infra"),
+        ],
+      ),
+    ).toEqual([{ displayAsLink: true, url: "https://app.example.com:8443/" }]);
+  });
+
+  test("does not make wildcard hostnames clickable", () => {
+    expect(getHTTPRouteLinks(route({ hostnames: ["*.example.com"] }), [])).toEqual([
+      { displayAsLink: false, url: "http://*.example.com/" },
+    ]);
+  });
+});

--- a/src/renderer/pages/k8s/http-route-links.ts
+++ b/src/renderer/pages/k8s/http-route-links.ts
@@ -1,0 +1,137 @@
+import type { Listener } from "../../api/k8s/gateway-v1";
+import type { HTTPRouteRule } from "../../api/k8s/http-route-v1";
+import type { ParentReference } from "../../api/k8s/types";
+
+const gatewayApiGroup = "gateway.networking.k8s.io";
+
+interface HTTPRouteForLinks {
+  getNs(): string | undefined;
+  spec?: {
+    hostnames?: string[];
+    parentRefs?: ParentReference[];
+    rules?: HTTPRouteRule[];
+  };
+}
+
+interface GatewayForLinks {
+  getName(): string;
+  getNs(): string | undefined;
+  spec?: {
+    listeners?: Listener[];
+  };
+}
+
+interface RouteEndpoint {
+  scheme: "http" | "https";
+  port: number;
+}
+
+export interface HTTPRouteLink {
+  displayAsLink: boolean;
+  url: string;
+}
+
+function unique<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}
+
+function getPaths(rules: HTTPRouteRule[] | undefined): string[] {
+  if (!rules || rules.length === 0) {
+    return ["/"];
+  }
+
+  return unique(
+    rules.flatMap((rule) => {
+      if (!rule.matches || rule.matches.length === 0) {
+        return ["/"];
+      }
+
+      return rule.matches.map((match) => (match.path?.type === "RegularExpression" ? "/" : (match.path?.value ?? "/")));
+    }),
+  );
+}
+
+function isGatewayReference(parentRef: ParentReference): boolean {
+  return (parentRef.group ?? gatewayApiGroup) === gatewayApiGroup && (parentRef.kind ?? "Gateway") === "Gateway";
+}
+
+function listenerMatchesReference(listener: Listener, parentRef: ParentReference): boolean {
+  return (
+    (!parentRef.sectionName || listener.name === parentRef.sectionName) &&
+    (!parentRef.port || listener.port === parentRef.port)
+  );
+}
+
+function listenerMatchesHostname(listenerHostname: string | undefined, routeHostname: string): boolean {
+  if (!listenerHostname) {
+    return true;
+  }
+
+  if (!listenerHostname.startsWith("*.")) {
+    return listenerHostname === routeHostname;
+  }
+
+  return routeHostname.endsWith(listenerHostname.slice(1));
+}
+
+function getEndpoints(route: HTTPRouteForLinks, gateways: GatewayForLinks[], hostname: string): RouteEndpoint[] {
+  const routeNamespace = route.getNs();
+
+  const endpoints = (route.spec?.parentRefs ?? []).filter(isGatewayReference).flatMap((parentRef) => {
+    const gatewayNamespace = parentRef.namespace ?? routeNamespace;
+    const gateway = gateways.find(
+      (candidate) => candidate.getName() === parentRef.name && candidate.getNs() === gatewayNamespace,
+    );
+
+    return (gateway?.spec?.listeners ?? [])
+      .filter((listener) => listenerMatchesReference(listener, parentRef))
+      .filter((listener) => listenerMatchesHostname(listener.hostname, hostname))
+      .flatMap((listener): RouteEndpoint[] => {
+        if (listener.protocol === "HTTP") {
+          return [{ scheme: "http", port: listener.port }];
+        }
+
+        if (listener.protocol === "HTTPS") {
+          return [{ scheme: "https", port: listener.port }];
+        }
+
+        return [];
+      });
+  });
+
+  if (endpoints.length === 0) {
+    return [{ scheme: "http", port: 80 }];
+  }
+
+  const uniqueEndpoints = new Map(endpoints.map((endpoint) => [`${endpoint.scheme}:${endpoint.port}`, endpoint]));
+
+  return [...uniqueEndpoints.values()].sort((left, right) => {
+    if (left.scheme !== right.scheme) {
+      return left.scheme === "https" ? -1 : 1;
+    }
+
+    return left.port - right.port;
+  });
+}
+
+function formatUrl(hostname: string, path: string, endpoint: RouteEndpoint): string {
+  const defaultPort = endpoint.scheme === "https" ? 443 : 80;
+  const port = endpoint.port === defaultPort ? "" : `:${endpoint.port}`;
+
+  return `${endpoint.scheme}://${hostname}${port}${path}`;
+}
+
+export function getHTTPRouteLinks(route: HTTPRouteForLinks, gateways: GatewayForLinks[]): HTTPRouteLink[] {
+  const paths = getPaths(route.spec?.rules);
+
+  return unique(
+    (route.spec?.hostnames ?? []).flatMap((hostname) =>
+      getEndpoints(route, gateways, hostname).flatMap((endpoint) =>
+        paths.map((path) => formatUrl(hostname, path, endpoint)),
+      ),
+    ),
+  ).map((url) => ({
+    displayAsLink: !url.includes("*"),
+    url,
+  }));
+}

--- a/src/renderer/pages/k8s/http-routes-page-v1.tsx
+++ b/src/renderer/pages/k8s/http-routes-page-v1.tsx
@@ -1,7 +1,8 @@
 import { Renderer } from "@freelensapp/extensions";
-import { HTTPRoute } from "../../api/k8s";
+import { Gateway, HTTPRoute } from "../../api/k8s";
 import { withErrorPage } from "../../components/error-page";
 import { observer } from "../../observer";
+import { getHTTPRouteLinks, type HTTPRouteLink } from "./http-route-links";
 import styles from "./http-routes-page-v1.module.scss";
 import stylesInline from "./http-routes-page-v1.module.scss?inline";
 import { type GatewayPageProps, namespaceCell } from "./shared";
@@ -22,9 +23,29 @@ function isAccepted(item: HTTPRoute): boolean {
   );
 }
 
+function renderRouteLinks(links: HTTPRouteLink[]) {
+  if (links.length === 0) {
+    return "*";
+  }
+
+  return links.map((link, index) => (
+    <span key={link.url}>
+      {index > 0 && ", "}
+      {link.displayAsLink ? (
+        <a href={link.url} rel="noreferrer" target="_blank" onClick={(event) => event.stopPropagation()}>
+          {link.url}
+        </a>
+      ) : (
+        link.url
+      )}
+    </span>
+  ));
+}
+
 export const HTTPRoutesPage = observer((props: GatewayPageProps) =>
   withErrorPage(props, () => {
     const store = HTTPRoute.getStore<HTTPRoute>();
+    const gatewayStore = Gateway.getStore<Gateway>();
 
     return (
       <>
@@ -33,6 +54,7 @@ export const HTTPRoutesPage = observer((props: GatewayPageProps) =>
           tableId={`${HTTPRoute.crd.plural}Table`}
           className={styles.page}
           store={store}
+          dependentStores={[gatewayStore]}
           sortingCallbacks={{
             name: (item: HTTPRoute) => item.getName(),
             namespace: (item: HTTPRoute) => item.getNs() ?? "",
@@ -45,14 +67,14 @@ export const HTTPRoutesPage = observer((props: GatewayPageProps) =>
           renderTableHeader={[
             { title: "Name", sortBy: "name", className: styles.name },
             { title: "Namespace", sortBy: "namespace", className: styles.namespace },
-            { title: "Hostnames", sortBy: "hostnames", className: styles.hostnames },
+            { title: "Routes", sortBy: "hostnames", className: styles.hostnames },
             { title: "Accepted", sortBy: "accepted", className: styles.accepted },
             { title: "Age", sortBy: "age", className: styles.age },
           ]}
           renderTableContents={(item: HTTPRoute) => [
             <WithTooltip>{item.getName()}</WithTooltip>,
             namespaceCell(item.getNs()),
-            <WithTooltip>{getHostnames(item).join(", ") || "*"}</WithTooltip>,
+            <WithTooltip>{renderRouteLinks(getHTTPRouteLinks(item, gatewayStore.items))}</WithTooltip>,
             <BadgeBoolean value={isAccepted(item)} />,
             <KubeObjectAge object={item} key="age" />,
           ]}


### PR DESCRIPTION
Closes #79

## Changes

- render HTTPRoute hostnames and match paths as external links
- derive HTTP/HTTPS schemes and non-default ports from referenced Gateway listeners
- keep wildcard hostnames as plain text and fall back to HTTP when the Gateway is unavailable
- load the Gateway store alongside the HTTPRoute list

## Validation

- pnpm test:unit
- pnpm type:check
- pnpm lint:check
- pnpm build